### PR TITLE
Resolve dist folders throwing lint warning during commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
+    "!(*d).ts": [
+      "eslint --fix --max-warnings 0",
+      "git add"
+    ],
+    "*.tsx": [
       "eslint --fix --max-warnings 0",
       "git add"
     ],


### PR DESCRIPTION
Closes #87

Changed the lint-staged file filter for .ts files to ignore .d.ts files in dist folders