### PR TITLE
Add access token as part of OpenSRPService instance initialization args

### DIFF
--- a/packages/opensrp-server-service/dist/serviceClass.js
+++ b/packages/opensrp-server-service/dist/serviceClass.js
@@ -1,430 +1,550 @@
-"use strict";
+'use strict';
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault');
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
+Object.defineProperty(exports, '__esModule', {
+  value: true,
 });
 exports.getDefaultHeaders = getDefaultHeaders;
 exports.getFetchOptions = getFetchOptions;
 exports.OpenSRPService = exports.customFetch = exports.OPENSRP_API_BASE_URL = void 0;
 
-var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
+var _slicedToArray2 = _interopRequireDefault(require('@babel/runtime/helpers/slicedToArray'));
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+var _classCallCheck2 = _interopRequireDefault(require('@babel/runtime/helpers/classCallCheck'));
 
-var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
+var _createClass2 = _interopRequireDefault(require('@babel/runtime/helpers/createClass'));
 
-var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
+var _defineProperty2 = _interopRequireDefault(require('@babel/runtime/helpers/defineProperty'));
 
-var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
+var _regenerator = _interopRequireDefault(require('@babel/runtime/regenerator'));
 
-var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+var _asyncToGenerator2 = _interopRequireDefault(require('@babel/runtime/helpers/asyncToGenerator'));
 
-var _querystring = _interopRequireDefault(require("querystring"));
+var _querystring = _interopRequireDefault(require('querystring'));
 
-var _errors = require("./errors");
+var _errors = require('./errors');
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) {
+  var keys = Object.keys(object);
+  if (Object.getOwnPropertySymbols) {
+    var symbols = Object.getOwnPropertySymbols(object);
+    if (enumerableOnly)
+      symbols = symbols.filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+      });
+    keys.push.apply(keys, symbols);
+  }
+  return keys;
+}
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i] != null ? arguments[i] : {};
+    if (i % 2) {
+      ownKeys(Object(source), true).forEach(function (key) {
+        (0, _defineProperty2['default'])(target, key, source[key]);
+      });
+    } else if (Object.getOwnPropertyDescriptors) {
+      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+    } else {
+      ownKeys(Object(source)).forEach(function (key) {
+        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+      });
+    }
+  }
+  return target;
+}
 
 var OPENSRP_API_BASE_URL = 'https://opensrp-stage.smartregister.org/opensrp/rest/';
 exports.OPENSRP_API_BASE_URL = OPENSRP_API_BASE_URL;
 
-function getDefaultHeaders() {
-  var accessToken = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'hunter2';
-  var accept = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'application/json';
-  var authorizationType = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'Bearer';
-  var contentType = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'application/json;charset=UTF-8';
+function getDefaultHeaders(accessToken) {
+  var accept =
+    arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'application/json';
+  var authorizationType =
+    arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'Bearer';
+  var contentType =
+    arguments.length > 3 && arguments[3] !== undefined
+      ? arguments[3]
+      : 'application/json;charset=UTF-8';
   return {
     accept: accept,
-    authorization: "".concat(authorizationType, " ").concat(accessToken),
-    'content-type': contentType
+    authorization: ''.concat(authorizationType, ' ').concat(accessToken),
+    'content-type': contentType,
   };
 }
 
-function getFetchOptions(signal, method) {
+function getFetchOptions(_, accessToken, method) {
   return {
-    headers: getDefaultHeaders(),
-    method: method
+    headers: getDefaultHeaders(accessToken),
+    method: method,
   };
 }
 
-var customFetch = function () {
-  var _ref = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee() {
-    var _args = arguments;
-    return _regenerator["default"].wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.prev = 0;
-            _context.next = 3;
-            return fetch.apply(void 0, _args);
+var customFetch = (function () {
+  var _ref = (0, _asyncToGenerator2['default'])(
+    _regenerator['default'].mark(function _callee() {
+      var _args = arguments;
+      return _regenerator['default'].wrap(
+        function _callee$(_context) {
+          while (1) {
+            switch ((_context.prev = _context.next)) {
+              case 0:
+                _context.prev = 0;
+                _context.next = 3;
+                return fetch.apply(void 0, _args);
 
-          case 3:
-            return _context.abrupt("return", _context.sent);
+              case 3:
+                return _context.abrupt('return', _context.sent);
 
-          case 6:
-            _context.prev = 6;
-            _context.t0 = _context["catch"](0);
-            (0, _errors.throwNetworkError)(_context.t0);
+              case 6:
+                _context.prev = 6;
+                _context.t0 = _context['catch'](0);
+                (0, _errors.throwNetworkError)(_context.t0);
 
-          case 9:
-          case "end":
-            return _context.stop();
-        }
-      }
-    }, _callee, null, [[0, 6]]);
-  }));
+              case 9:
+              case 'end':
+                return _context.stop();
+            }
+          }
+        },
+        _callee,
+        null,
+        [[0, 6]]
+      );
+    })
+  );
 
   return function customFetch() {
     return _ref.apply(this, arguments);
   };
-}();
+})();
 
 exports.customFetch = customFetch;
 
-var OpenSRPService = function () {
-  function OpenSRPService() {
-    var baseURL = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : OPENSRP_API_BASE_URL;
-    var endpoint = arguments.length > 1 ? arguments[1] : undefined;
-    var getPayload = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : getFetchOptions;
-    var signal = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : new AbortController().signal;
-    (0, _classCallCheck2["default"])(this, OpenSRPService);
-    (0, _defineProperty2["default"])(this, "baseURL", void 0);
-    (0, _defineProperty2["default"])(this, "endpoint", void 0);
-    (0, _defineProperty2["default"])(this, "generalURL", void 0);
-    (0, _defineProperty2["default"])(this, "getOptions", void 0);
-    (0, _defineProperty2["default"])(this, "signal", void 0);
+var OpenSRPService = (function () {
+  function OpenSRPService(accessToken) {
+    var baseURL =
+      arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : OPENSRP_API_BASE_URL;
+    var endpoint = arguments.length > 2 ? arguments[2] : undefined;
+    var getPayload =
+      arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : getFetchOptions;
+    var signal =
+      arguments.length > 4 && arguments[4] !== undefined
+        ? arguments[4]
+        : new AbortController().signal;
+    (0, _classCallCheck2['default'])(this, OpenSRPService);
+    (0, _defineProperty2['default'])(this, 'accessToken', void 0);
+    (0, _defineProperty2['default'])(this, 'baseURL', void 0);
+    (0, _defineProperty2['default'])(this, 'endpoint', void 0);
+    (0, _defineProperty2['default'])(this, 'generalURL', void 0);
+    (0, _defineProperty2['default'])(this, 'getOptions', void 0);
+    (0, _defineProperty2['default'])(this, 'signal', void 0);
     this.endpoint = endpoint;
     this.getOptions = getPayload;
     this.signal = signal;
     this.baseURL = baseURL;
-    this.generalURL = "".concat(this.baseURL).concat(this.endpoint);
+    this.generalURL = ''.concat(this.baseURL).concat(this.endpoint);
+    this.accessToken = accessToken;
   }
 
-  (0, _createClass2["default"])(OpenSRPService, [{
-    key: "create",
-    value: function () {
-      var _create = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee2(data) {
-        var params,
-            method,
-            url,
-            payload,
-            response,
-            defaultMessage,
-            _args2 = arguments;
-        return _regenerator["default"].wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                params = _args2.length > 1 && _args2[1] !== undefined ? _args2[1] : null;
-                method = _args2.length > 2 && _args2[2] !== undefined ? _args2[2] : 'POST';
-                url = OpenSRPService.getURL(this.generalURL, params);
-                payload = _objectSpread(_objectSpread({}, this.getOptions(this.signal, method)), {}, {
-                  'Cache-Control': 'no-cache',
-                  Pragma: 'no-cache',
-                  body: JSON.stringify(data)
-                });
-                _context2.next = 6;
-                return customFetch(url, payload);
+  (0, _createClass2['default'])(
+    OpenSRPService,
+    [
+      {
+        key: 'create',
+        value: (function () {
+          var _create = (0, _asyncToGenerator2['default'])(
+            _regenerator['default'].mark(function _callee2(data) {
+              var params,
+                method,
+                url,
+                payload,
+                response,
+                defaultMessage,
+                _args2 = arguments;
+              return _regenerator['default'].wrap(
+                function _callee2$(_context2) {
+                  while (1) {
+                    switch ((_context2.prev = _context2.next)) {
+                      case 0:
+                        params = _args2.length > 1 && _args2[1] !== undefined ? _args2[1] : null;
+                        method = _args2.length > 2 && _args2[2] !== undefined ? _args2[2] : 'POST';
+                        url = OpenSRPService.getURL(this.generalURL, params);
+                        payload = _objectSpread(
+                          _objectSpread({}, this.getOptions(this.signal, this.accessToken, method)),
+                          {},
+                          {
+                            'Cache-Control': 'no-cache',
+                            Pragma: 'no-cache',
+                            body: JSON.stringify(data),
+                          }
+                        );
+                        _context2.next = 6;
+                        return customFetch(url, payload);
 
-              case 6:
-                response = _context2.sent;
+                      case 6:
+                        response = _context2.sent;
 
-                if (!response) {
-                  _context2.next = 13;
-                  break;
-                }
+                        if (!response) {
+                          _context2.next = 13;
+                          break;
+                        }
 
-                if (!(response.ok || response.status === 201)) {
-                  _context2.next = 10;
-                  break;
-                }
+                        if (!(response.ok || response.status === 201)) {
+                          _context2.next = 10;
+                          break;
+                        }
 
-                return _context2.abrupt("return", {});
+                        return _context2.abrupt('return', {});
 
-              case 10:
-                defaultMessage = "OpenSRPService create on ".concat(this.endpoint, " failed, HTTP status ").concat(response === null || response === void 0 ? void 0 : response.status);
-                _context2.next = 13;
-                return (0, _errors.throwHTTPError)(response, defaultMessage);
+                      case 10:
+                        defaultMessage = 'OpenSRPService create on '
+                          .concat(this.endpoint, ' failed, HTTP status ')
+                          .concat(
+                            response === null || response === void 0 ? void 0 : response.status
+                          );
+                        _context2.next = 13;
+                        return (0, _errors.throwHTTPError)(response, defaultMessage);
 
-              case 13:
-                return _context2.abrupt("return", {});
+                      case 13:
+                        return _context2.abrupt('return', {});
 
-              case 14:
-              case "end":
-                return _context2.stop();
-            }
+                      case 14:
+                      case 'end':
+                        return _context2.stop();
+                    }
+                  }
+                },
+                _callee2,
+                this
+              );
+            })
+          );
+
+          function create(_x) {
+            return _create.apply(this, arguments);
           }
-        }, _callee2, this);
-      }));
 
-      function create(_x) {
-        return _create.apply(this, arguments);
-      }
+          return create;
+        })(),
+      },
+      {
+        key: 'read',
+        value: (function () {
+          var _read = (0, _asyncToGenerator2['default'])(
+            _regenerator['default'].mark(function _callee3(id) {
+              var params,
+                method,
+                url,
+                response,
+                defaultMessage,
+                _args3 = arguments;
+              return _regenerator['default'].wrap(
+                function _callee3$(_context3) {
+                  while (1) {
+                    switch ((_context3.prev = _context3.next)) {
+                      case 0:
+                        params = _args3.length > 1 && _args3[1] !== undefined ? _args3[1] : null;
+                        method = _args3.length > 2 && _args3[2] !== undefined ? _args3[2] : 'GET';
+                        url = OpenSRPService.getURL(
+                          ''.concat(this.generalURL, '/').concat(id),
+                          params
+                        );
+                        _context3.next = 5;
+                        return customFetch(
+                          url,
+                          this.getOptions(this.signal, this.accessToken, method)
+                        );
 
-      return create;
-    }()
-  }, {
-    key: "read",
-    value: function () {
-      var _read = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee3(id) {
-        var params,
-            method,
-            url,
-            response,
-            defaultMessage,
-            _args3 = arguments;
-        return _regenerator["default"].wrap(function _callee3$(_context3) {
-          while (1) {
-            switch (_context3.prev = _context3.next) {
-              case 0:
-                params = _args3.length > 1 && _args3[1] !== undefined ? _args3[1] : null;
-                method = _args3.length > 2 && _args3[2] !== undefined ? _args3[2] : 'GET';
-                url = OpenSRPService.getURL("".concat(this.generalURL, "/").concat(id), params);
-                _context3.next = 5;
-                return customFetch(url, this.getOptions(this.signal, method));
+                      case 5:
+                        response = _context3.sent;
 
-              case 5:
-                response = _context3.sent;
+                        if (!response) {
+                          _context3.next = 14;
+                          break;
+                        }
 
-                if (!response) {
-                  _context3.next = 14;
-                  break;
-                }
+                        if (!response.ok) {
+                          _context3.next = 11;
+                          break;
+                        }
 
-                if (!response.ok) {
-                  _context3.next = 11;
-                  break;
-                }
+                        _context3.next = 10;
+                        return response.json();
 
-                _context3.next = 10;
-                return response.json();
+                      case 10:
+                        return _context3.abrupt('return', _context3.sent);
 
-              case 10:
-                return _context3.abrupt("return", _context3.sent);
+                      case 11:
+                        defaultMessage = 'OpenSRPService read on '
+                          .concat(this.endpoint, ' failed, HTTP status ')
+                          .concat(response.status);
+                        _context3.next = 14;
+                        return (0, _errors.throwHTTPError)(response, defaultMessage);
 
-              case 11:
-                defaultMessage = "OpenSRPService read on ".concat(this.endpoint, " failed, HTTP status ").concat(response.status);
-                _context3.next = 14;
-                return (0, _errors.throwHTTPError)(response, defaultMessage);
+                      case 14:
+                      case 'end':
+                        return _context3.stop();
+                    }
+                  }
+                },
+                _callee3,
+                this
+              );
+            })
+          );
 
-              case 14:
-              case "end":
-                return _context3.stop();
-            }
+          function read(_x2) {
+            return _read.apply(this, arguments);
           }
-        }, _callee3, this);
-      }));
 
-      function read(_x2) {
-        return _read.apply(this, arguments);
-      }
+          return read;
+        })(),
+      },
+      {
+        key: 'update',
+        value: (function () {
+          var _update = (0, _asyncToGenerator2['default'])(
+            _regenerator['default'].mark(function _callee4(data) {
+              var params,
+                method,
+                url,
+                payload,
+                response,
+                defaultMessage,
+                _args4 = arguments;
+              return _regenerator['default'].wrap(
+                function _callee4$(_context4) {
+                  while (1) {
+                    switch ((_context4.prev = _context4.next)) {
+                      case 0:
+                        params = _args4.length > 1 && _args4[1] !== undefined ? _args4[1] : null;
+                        method = _args4.length > 2 && _args4[2] !== undefined ? _args4[2] : 'PUT';
+                        url = OpenSRPService.getURL(this.generalURL, params);
+                        payload = _objectSpread(
+                          _objectSpread({}, this.getOptions(this.signal, this.accessToken, method)),
+                          {},
+                          {
+                            'Cache-Control': 'no-cache',
+                            Pragma: 'no-cache',
+                            body: JSON.stringify(data),
+                          }
+                        );
+                        _context4.next = 6;
+                        return customFetch(url, payload);
 
-      return read;
-    }()
-  }, {
-    key: "update",
-    value: function () {
-      var _update = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee4(data) {
-        var params,
-            method,
-            url,
-            payload,
-            response,
-            defaultMessage,
-            _args4 = arguments;
-        return _regenerator["default"].wrap(function _callee4$(_context4) {
-          while (1) {
-            switch (_context4.prev = _context4.next) {
-              case 0:
-                params = _args4.length > 1 && _args4[1] !== undefined ? _args4[1] : null;
-                method = _args4.length > 2 && _args4[2] !== undefined ? _args4[2] : 'PUT';
-                url = OpenSRPService.getURL(this.generalURL, params);
-                payload = _objectSpread(_objectSpread({}, this.getOptions(this.signal, method)), {}, {
-                  'Cache-Control': 'no-cache',
-                  Pragma: 'no-cache',
-                  body: JSON.stringify(data)
-                });
-                _context4.next = 6;
-                return customFetch(url, payload);
+                      case 6:
+                        response = _context4.sent;
 
-              case 6:
-                response = _context4.sent;
+                        if (!response) {
+                          _context4.next = 13;
+                          break;
+                        }
 
-                if (!response) {
-                  _context4.next = 13;
-                  break;
-                }
+                        if (!response.ok) {
+                          _context4.next = 10;
+                          break;
+                        }
 
-                if (!response.ok) {
-                  _context4.next = 10;
-                  break;
-                }
+                        return _context4.abrupt('return', {});
 
-                return _context4.abrupt("return", {});
+                      case 10:
+                        defaultMessage = 'OpenSRPService update on '
+                          .concat(this.endpoint, ' failed, HTTP status ')
+                          .concat(response.status);
+                        _context4.next = 13;
+                        return (0, _errors.throwHTTPError)(response, defaultMessage);
 
-              case 10:
-                defaultMessage = "OpenSRPService update on ".concat(this.endpoint, " failed, HTTP status ").concat(response.status);
-                _context4.next = 13;
-                return (0, _errors.throwHTTPError)(response, defaultMessage);
+                      case 13:
+                        return _context4.abrupt('return', {});
 
-              case 13:
-                return _context4.abrupt("return", {});
+                      case 14:
+                      case 'end':
+                        return _context4.stop();
+                    }
+                  }
+                },
+                _callee4,
+                this
+              );
+            })
+          );
 
-              case 14:
-              case "end":
-                return _context4.stop();
-            }
+          function update(_x3) {
+            return _update.apply(this, arguments);
           }
-        }, _callee4, this);
-      }));
 
-      function update(_x3) {
-        return _update.apply(this, arguments);
-      }
+          return update;
+        })(),
+      },
+      {
+        key: 'list',
+        value: (function () {
+          var _list = (0, _asyncToGenerator2['default'])(
+            _regenerator['default'].mark(function _callee5() {
+              var params,
+                method,
+                url,
+                response,
+                defaultMessage,
+                _args5 = arguments;
+              return _regenerator['default'].wrap(
+                function _callee5$(_context5) {
+                  while (1) {
+                    switch ((_context5.prev = _context5.next)) {
+                      case 0:
+                        params = _args5.length > 0 && _args5[0] !== undefined ? _args5[0] : null;
+                        method = _args5.length > 1 && _args5[1] !== undefined ? _args5[1] : 'GET';
+                        url = OpenSRPService.getURL(this.generalURL, params);
+                        _context5.next = 5;
+                        return customFetch(
+                          url,
+                          this.getOptions(this.signal, this.accessToken, method)
+                        );
 
-      return update;
-    }()
-  }, {
-    key: "list",
-    value: function () {
-      var _list = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee5() {
-        var params,
-            method,
-            url,
-            response,
-            defaultMessage,
-            _args5 = arguments;
-        return _regenerator["default"].wrap(function _callee5$(_context5) {
-          while (1) {
-            switch (_context5.prev = _context5.next) {
-              case 0:
-                params = _args5.length > 0 && _args5[0] !== undefined ? _args5[0] : null;
-                method = _args5.length > 1 && _args5[1] !== undefined ? _args5[1] : 'GET';
-                url = OpenSRPService.getURL(this.generalURL, params);
-                _context5.next = 5;
-                return customFetch(url, this.getOptions(this.signal, method));
+                      case 5:
+                        response = _context5.sent;
 
-              case 5:
-                response = _context5.sent;
+                        if (!response) {
+                          _context5.next = 14;
+                          break;
+                        }
 
-                if (!response) {
-                  _context5.next = 14;
-                  break;
-                }
+                        if (!response.ok) {
+                          _context5.next = 11;
+                          break;
+                        }
 
-                if (!response.ok) {
-                  _context5.next = 11;
-                  break;
-                }
+                        _context5.next = 10;
+                        return response.json();
 
-                _context5.next = 10;
-                return response.json();
+                      case 10:
+                        return _context5.abrupt('return', _context5.sent);
 
-              case 10:
-                return _context5.abrupt("return", _context5.sent);
+                      case 11:
+                        defaultMessage = 'OpenSRPService list on '
+                          .concat(this.endpoint, ' failed, HTTP status ')
+                          .concat(response.status);
+                        _context5.next = 14;
+                        return (0, _errors.throwHTTPError)(response, defaultMessage);
 
-              case 11:
-                defaultMessage = "OpenSRPService list on ".concat(this.endpoint, " failed, HTTP status ").concat(response.status);
-                _context5.next = 14;
-                return (0, _errors.throwHTTPError)(response, defaultMessage);
+                      case 14:
+                      case 'end':
+                        return _context5.stop();
+                    }
+                  }
+                },
+                _callee5,
+                this
+              );
+            })
+          );
 
-              case 14:
-              case "end":
-                return _context5.stop();
-            }
+          function list() {
+            return _list.apply(this, arguments);
           }
-        }, _callee5, this);
-      }));
 
-      function list() {
-        return _list.apply(this, arguments);
-      }
+          return list;
+        })(),
+      },
+      {
+        key: 'delete',
+        value: (function () {
+          var _delete2 = (0, _asyncToGenerator2['default'])(
+            _regenerator['default'].mark(function _callee6() {
+              var params,
+                method,
+                url,
+                response,
+                defaultMessage,
+                _args6 = arguments;
+              return _regenerator['default'].wrap(
+                function _callee6$(_context6) {
+                  while (1) {
+                    switch ((_context6.prev = _context6.next)) {
+                      case 0:
+                        params = _args6.length > 0 && _args6[0] !== undefined ? _args6[0] : null;
+                        method =
+                          _args6.length > 1 && _args6[1] !== undefined ? _args6[1] : 'DELETE';
+                        url = OpenSRPService.getURL(this.generalURL, params);
+                        _context6.next = 5;
+                        return fetch(url, this.getOptions(this.signal, this.accessToken, method));
 
-      return list;
-    }()
-  }, {
-    key: "delete",
-    value: function () {
-      var _delete2 = (0, _asyncToGenerator2["default"])(_regenerator["default"].mark(function _callee6() {
-        var params,
-            method,
-            url,
-            response,
-            defaultMessage,
-            _args6 = arguments;
-        return _regenerator["default"].wrap(function _callee6$(_context6) {
-          while (1) {
-            switch (_context6.prev = _context6.next) {
-              case 0:
-                params = _args6.length > 0 && _args6[0] !== undefined ? _args6[0] : null;
-                method = _args6.length > 1 && _args6[1] !== undefined ? _args6[1] : 'DELETE';
-                url = OpenSRPService.getURL(this.generalURL, params);
-                _context6.next = 5;
-                return fetch(url, this.getOptions(this.signal, method));
+                      case 5:
+                        response = _context6.sent;
 
-              case 5:
-                response = _context6.sent;
+                        if (!response) {
+                          _context6.next = 12;
+                          break;
+                        }
 
-                if (!response) {
-                  _context6.next = 12;
-                  break;
-                }
+                        if (!(response.ok || response.status === 204 || response.status === 200)) {
+                          _context6.next = 9;
+                          break;
+                        }
 
-                if (!(response.ok || response.status === 204 || response.status === 200)) {
-                  _context6.next = 9;
-                  break;
-                }
+                        return _context6.abrupt('return', {});
 
-                return _context6.abrupt("return", {});
+                      case 9:
+                        defaultMessage = 'OpenSRPService delete on '
+                          .concat(this.endpoint, ' failed, HTTP status ')
+                          .concat(response.status);
+                        _context6.next = 12;
+                        return (0, _errors.throwHTTPError)(response, defaultMessage);
 
-              case 9:
-                defaultMessage = "OpenSRPService delete on ".concat(this.endpoint, " failed, HTTP status ").concat(response.status);
-                _context6.next = 12;
-                return (0, _errors.throwHTTPError)(response, defaultMessage);
+                      case 12:
+                        return _context6.abrupt('return', {});
 
-              case 12:
-                return _context6.abrupt("return", {});
+                      case 13:
+                      case 'end':
+                        return _context6.stop();
+                    }
+                  }
+                },
+                _callee6,
+                this
+              );
+            })
+          );
 
-              case 13:
-              case "end":
-                return _context6.stop();
-            }
+          function _delete() {
+            return _delete2.apply(this, arguments);
           }
-        }, _callee6, this);
-      }));
 
-      function _delete() {
-        return _delete2.apply(this, arguments);
-      }
+          return _delete;
+        })(),
+      },
+    ],
+    [
+      {
+        key: 'getURL',
+        value: function getURL(generalUrl, params) {
+          if (params) {
+            return ''.concat(generalUrl, '?').concat(_querystring['default'].stringify(params));
+          }
 
-      return _delete;
-    }()
-  }], [{
-    key: "getURL",
-    value: function getURL(generalUrl, params) {
-      if (params) {
-        return "".concat(generalUrl, "?").concat(_querystring["default"].stringify(params));
-      }
+          return generalUrl;
+        },
+      },
+      {
+        key: 'getFilterParams',
+        value: function getFilterParams(obj) {
+          return Object.entries(obj)
+            .map(function (_ref2) {
+              var _ref3 = (0, _slicedToArray2['default'])(_ref2, 2),
+                key = _ref3[0],
+                val = _ref3[1];
 
-      return generalUrl;
-    }
-  }, {
-    key: "getFilterParams",
-    value: function getFilterParams(obj) {
-      return Object.entries(obj).map(function (_ref2) {
-        var _ref3 = (0, _slicedToArray2["default"])(_ref2, 2),
-            key = _ref3[0],
-            val = _ref3[1];
-
-        return "".concat(key, ":").concat(val);
-      }).join(',');
-    }
-  }]);
+              return ''.concat(key, ':').concat(val);
+            })
+            .join(',');
+        },
+      },
+    ]
+  );
   return OpenSRPService;
-}();
+})();
 
 exports.OpenSRPService = OpenSRPService;

--- a/packages/opensrp-server-service/dist/types/serviceClass.d.ts
+++ b/packages/opensrp-server-service/dist/types/serviceClass.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { IncomingHttpHeaders } from 'http';
 /** defaults */
-export declare const OPENSRP_API_BASE_URL = "https://opensrp-stage.smartregister.org/opensrp/rest/";
+export declare const OPENSRP_API_BASE_URL = 'https://opensrp-stage.smartregister.org/opensrp/rest/';
 /** allowed http methods */
 declare type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 /** get default HTTP headers for OpenSRP service
@@ -12,23 +12,34 @@ declare type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
  * @param {string} contentType - the content type
  * @returns {IncomingHttpHeaders} - the headers
  */
-export declare function getDefaultHeaders(accessToken?: string, accept?: string, authorizationType?: string, contentType?: string): IncomingHttpHeaders;
-/** get payload for fetch
+export declare function getDefaultHeaders(
+  accessToken: string,
+  accept?: string,
+  authorizationType?: string,
+  contentType?: string
+): IncomingHttpHeaders;
+/**
+ * get payload for fetch
  *
- * @param {AbortSignal} signal - signal object that allows you to communicate with a DOM request
+ * @param {object} _ - signal object that allows you to communicate with a DOM request
+ * @param {string} accessToken - the access token
  * @param {string} method - the HTTP method
- * @returns {object} - the payload
+ * @returns {Object} the payload
  */
-export declare function getFetchOptions(signal: AbortSignal, method: HTTPMethod): {
-    headers: HeadersInit;
-    method: HTTPMethod;
+export declare function getFetchOptions(
+  _: AbortSignal,
+  accessToken: string,
+  method: HTTPMethod
+): {
+  headers: HeadersInit;
+  method: HTTPMethod;
 };
 /** interface to describe URL params object */
 export interface URLParams {
-    [key: string]: string | number | boolean;
+  [key: string]: string | number | boolean;
 }
 export interface CustomFetch {
-    (input: RequestInfo, init?: RequestInit | undefined): Promise<Response | undefined>;
+  (input: RequestInfo, init?: RequestInit | undefined): Promise<Response | undefined>;
 }
 export declare const customFetch: CustomFetch;
 /** params option type */
@@ -48,78 +59,86 @@ declare type paramsType = URLParams | null;
  * **To update an object**: service.update(theObject)
  */
 export declare class OpenSRPService {
-    baseURL: string;
-    endpoint: string;
-    generalURL: string;
-    getOptions: typeof getFetchOptions;
-    signal: AbortSignal;
-    /**
-     * Constructor method
-     *
-     * @param {string} baseURL - the base OpenSRP API URL
-     * @param {string} endpoint - the OpenSRP endpoint
-     * @param {function()} getPayload - a function to get the payload
-     * @param {AbortController} signal - abort signal
-     */
-    constructor(baseURL: string | undefined, endpoint: string, getPayload?: typeof getFetchOptions, signal?: AbortSignal);
-    /** appends any query params to the url as a querystring
-     *
-     * @param {string} generalUrl - the url
-     * @param {object} params - the url params object
-     * @returns {string} the final url
-     */
-    static getURL(generalUrl: string, params: paramsType): string;
-    /** converts filter params object to string
-     *
-     * @param {object} obj - the object representing filter params
-     * @returns {string} filter params as a string
-     */
-    static getFilterParams(obj: URLParams | Record<string, unknown>): string;
-    /** create method
-     * Send a POST request to the general endpoint containing the new object data
-     * Successful requests will result in a HTTP status 201 response with no body
-     *
-     * @param {object} data - the data to be POSTed
-     * @param {params} params - the url params object
-     * @param {string} method - the HTTP method
-     * @returns {object} the object returned by API
-     */
-    create<T>(data: T, params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
-    /** read method
-     * Send a GET request to the url for the specific object
-     *
-     * @param {string|number} id - the identifier of the object
-     * @param {params} params - the url params object
-     * @param {string} method - the HTTP method
-     * @returns {object} the object returned by API
-     */
-    read(id: string | number, params?: paramsType, method?: HTTPMethod): Promise<any>;
-    /** update method
-     * Simply send the updated object as PUT request to the general endpoint URL
-     * Successful requests will result in a HTTP status 200/201 response with no body
-     *
-     * @param {object} data - the data to be POSTed
-     * @param {params} params - the url params object
-     * @param {string} method - the HTTP method
-     * @returns {object} the object returned by API
-     */
-    update<T>(data: T, params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
-    /** list method
-     * Send a GET request to the general API endpoint
-     *
-     * @param {params} params - the url params object
-     * @param {string} method - the HTTP method
-     * @returns {object} list of objects returned by API
-     */
-    list(params?: paramsType, method?: HTTPMethod): Promise<any>;
-    /** delete method
-     * Send a DELETE request to the general endpoint
-     * Successful requests will result in a HTTP status 204
-     *
-     * @param {params} params - the url params object
-     * @param {string} method - the HTTP method
-     * @returns {object} the object returned by API
-     */
-    delete<T>(params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
+  accessToken: string;
+  baseURL: string;
+  endpoint: string;
+  generalURL: string;
+  getOptions: typeof getFetchOptions;
+  signal: AbortSignal;
+  /**
+   * Constructor method
+   *
+   * @param {string} accessToken - the access token
+   * @param {string} baseURL - the base OpenSRP API URL
+   * @param {string} endpoint - the OpenSRP endpoint
+   * @param {function()} getPayload - a function to get the payload
+   * @param {AbortController} signal - abort signal
+   */
+  constructor(
+    accessToken: string,
+    baseURL: string | undefined,
+    endpoint: string,
+    getPayload?: typeof getFetchOptions,
+    signal?: AbortSignal
+  );
+  /** appends any query params to the url as a querystring
+   *
+   * @param {string} generalUrl - the url
+   * @param {object} params - the url params object
+   * @returns {string} the final url
+   */
+  static getURL(generalUrl: string, params: paramsType): string;
+  /** converts filter params object to string
+   *
+   * @param {object} obj - the object representing filter params
+   * @returns {string} filter params as a string
+   */
+  static getFilterParams(obj: URLParams | Record<string, unknown>): string;
+  /** create method
+   * Send a POST request to the general endpoint containing the new object data
+   * Successful requests will result in a HTTP status 201 response with no body
+   *
+   * @param {object} data - the data to be POSTed
+   * @param {params} params - the url params object
+   * @param {string} method - the HTTP method
+   * @returns {object} the object returned by API
+   */
+  create<T>(data: T, params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
+  /** read method
+   * Send a GET request to the url for the specific object
+   *
+   * @param {string|number} id - the identifier of the object
+   * @param {params} params - the url params object
+   * @param {string} method - the HTTP method
+   * @returns {object} the object returned by API
+   */
+  read(id: string | number, params?: paramsType, method?: HTTPMethod): Promise<any>;
+  /** update method
+   * Simply send the updated object as PUT request to the general endpoint URL
+   * Successful requests will result in a HTTP status 200/201 response with no body
+   *
+   * @param {object} data - the data to be POSTed
+   * @param {params} params - the url params object
+   * @param {string} method - the HTTP method
+   * @returns {object} the object returned by API
+   */
+  update<T>(data: T, params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
+  /** list method
+   * Send a GET request to the general API endpoint
+   *
+   * @param {params} params - the url params object
+   * @param {string} method - the HTTP method
+   * @returns {object} list of objects returned by API
+   */
+  list(params?: paramsType, method?: HTTPMethod): Promise<any>;
+  /** delete method
+   * Send a DELETE request to the general endpoint
+   * Successful requests will result in a HTTP status 204
+   *
+   * @param {params} params - the url params object
+   * @param {string} method - the HTTP method
+   * @returns {object} the object returned by API
+   */
+  delete<T>(params?: paramsType, method?: HTTPMethod): Promise<Record<string, unknown>>;
 }
 export {};

--- a/packages/opensrp-server-service/src/tests/index.test.ts
+++ b/packages/opensrp-server-service/src/tests/index.test.ts
@@ -21,7 +21,7 @@ describe('services/OpenSRP', () => {
   });
 
   it('OpenSRPService constructor works', async () => {
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     expect(planService.baseURL).toEqual('https://opensrp-stage.smartregister.org/opensrp/rest/');
     expect(planService.endpoint).toEqual('plans');
     expect(planService.generalURL).toEqual(
@@ -40,7 +40,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService list method works', async () => {
     fetch.mockResponseOnce(JSON.stringify(plansListResponse));
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     const result = await planService.list();
     expect(result).toEqual(plansListResponse);
     expect(fetch.mock.calls).toEqual([
@@ -60,7 +60,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService list method params work', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'location');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'location');
 
     await service.list({ is_jurisdiction: true });
     expect(fetch.mock.calls[0][0]).toEqual(
@@ -71,7 +71,7 @@ describe('services/OpenSRP', () => {
   it('OpenSRPService list method should handle http errors', async () => {
     const statusText = 'something happened';
     fetch.mockResponseOnce(JSON.stringify(sampleErrorObj), { status: 500, statusText });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     let error;
     try {
       await planService.list();
@@ -87,7 +87,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService delete method works', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'practitioners');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'practitioners');
     const result = await service.delete({ practitioner: 'someone' });
     expect(result).toEqual({});
     expect(fetch.mock.calls).toEqual([
@@ -107,7 +107,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService delete method on solo endpoint', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'practitioners/someId');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'practitioners/someId');
     const result = await service.delete();
     expect(result).toEqual({});
     expect(fetch.mock.calls).toEqual([
@@ -128,7 +128,7 @@ describe('services/OpenSRP', () => {
   it('OpenSRPService delete method should handle http errors', async () => {
     const statusText = 'something happened';
     fetch.mockResponseOnce(JSON.stringify(sampleErrorObj), { status: 500, statusText });
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'practitioners');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'practitioners');
     let error;
     try {
       await service.delete({});
@@ -147,7 +147,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService read method works', async () => {
     fetch.mockResponseOnce(JSON.stringify(plansListResponse[0]));
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     const result = await planService.read('0e85c238-39c1-4cea-a926-3d89f0c98427');
     expect(result).toEqual(plansListResponse[0]);
     expect(fetch.mock.calls).toEqual([
@@ -167,14 +167,14 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService read method handles null response', async () => {
     fetch.mockResponseOnce(JSON.stringify(null));
-    const taskService = new OpenSRPService(OPENSRP_API_BASE_URL, 'task');
+    const taskService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'task');
     const result = await taskService.read('079a7fe8-ef46-462f-9c5c-8b2490344e4a');
     expect(result).toEqual(null);
   });
 
   it('OpenSRPService read method params work', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'location');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'location');
 
     await service.read('62b2f313', { is_jurisdiction: true });
     expect(fetch.mock.calls[0][0]).toEqual(
@@ -185,7 +185,7 @@ describe('services/OpenSRP', () => {
   it('OpenSRPService read method should handle http errors', async () => {
     const statusText = 'something happened';
     fetch.mockResponseOnce(JSON.stringify(sampleErrorObj), { status: 500, statusText });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     let error;
     try {
       await planService.read('0e85c238-39c1-4cea-a926-3d89f0c98427');
@@ -200,7 +200,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService create method works', async () => {
     fetch.mockResponseOnce(JSON.stringify({}), { status: 201 });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     const result = await planService.create(createPlan);
     expect(result).toEqual({});
     expect(fetch.mock.calls).toEqual([
@@ -223,7 +223,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService create method params work', async () => {
     fetch.mockResponseOnce(JSON.stringify({}), { status: 201 });
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'location');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'location');
 
     await service.create({ foo: 'bar' }, { is_jurisdiction: true });
     expect(fetch.mock.calls[0][0]).toEqual(
@@ -234,7 +234,7 @@ describe('services/OpenSRP', () => {
   it('OpenSRPService create method should handle http errors', async () => {
     const statusText = 'something happened';
     fetch.mockResponseOnce(JSON.stringify(sampleErrorObj), { status: 500, statusText });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     let error;
     try {
       await planService.create({ foo: 'bar' });
@@ -249,7 +249,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService update method works', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     const obj = {
       ...createPlan,
       status: 'retired',
@@ -276,7 +276,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService update method params work', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
-    const service = new OpenSRPService(OPENSRP_API_BASE_URL, 'location');
+    const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'location');
 
     await service.update({ foo: 'bar' }, { is_jurisdiction: true });
     expect(fetch.mock.calls[0][0]).toEqual(
@@ -286,7 +286,7 @@ describe('services/OpenSRP', () => {
 
   it('OpenSRPService update method should handle http errors', async () => {
     fetch.mockResponseOnce(JSON.stringify({}), { status: 500 });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     let error;
     try {
       await planService.update({ foo: 'bar' });
@@ -300,7 +300,7 @@ describe('services/OpenSRP', () => {
     // json apiResponse object
     const statusText = 'something happened';
     fetch.mockResponseOnce(JSON.stringify('Some error happened'), { status: 500, statusText });
-    const planService = new OpenSRPService(OPENSRP_API_BASE_URL, 'plans');
+    const planService = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'plans');
     let error;
     try {
       await planService.update({ foo: 'bar' });


### PR DESCRIPTION
closes #110

Accept the access token in the constructor so as to build the headers. The previous implementation made method getFetchOptions unusable since getDefaultHeaders was being called with the same default value for accessToken