### PR TITLE
Modify OpensrpService class to make sure special chars are not escaped

### DIFF
--- a/packages/opensrp-server-service/src/serviceClass.ts
+++ b/packages/opensrp-server-service/src/serviceClass.ts
@@ -126,7 +126,7 @@ export class OpenSRPService<PayloadT extends object = Dictionary> {
    */
   public static getURL(generalUrl: string, params: paramsType): string {
     if (params) {
-      return `${generalUrl}?${queryString.stringify(params)}`;
+      return `${generalUrl}?${queryString.unescape(queryString.stringify(params))}`;
     }
     return generalUrl;
   }

--- a/packages/opensrp-server-service/src/serviceClass.ts
+++ b/packages/opensrp-server-service/src/serviceClass.ts
@@ -126,7 +126,7 @@ export class OpenSRPService<PayloadT extends object = Dictionary> {
    */
   public static getURL(generalUrl: string, params: paramsType): string {
     if (params) {
-      return `${generalUrl}?${queryString.unescape(queryString.stringify(params))}`;
+      return `${generalUrl}?${decodeURIComponent(queryString.stringify(params))}`;
     }
     return generalUrl;
   }

--- a/packages/opensrp-server-service/src/tests/index.test.ts
+++ b/packages/opensrp-server-service/src/tests/index.test.ts
@@ -62,9 +62,9 @@ describe('services/OpenSRP', () => {
     fetch.mockResponseOnce(JSON.stringify({}));
     const service = new OpenSRPService('hunter2', OPENSRP_API_BASE_URL, 'location');
 
-    await service.list({ is_jurisdiction: true });
+    await service.list({ is_jurisdiction: true, attribute: 'card_status:needs_card' });
     expect(fetch.mock.calls[0][0]).toEqual(
-      'https://opensrp-stage.smartregister.org/opensrp/rest/location?is_jurisdiction=true'
+      'https://opensrp-stage.smartregister.org/opensrp/rest/location?is_jurisdiction=true&attribute=card_status:needs_card'
     );
   });
 


### PR DESCRIPTION
Make sure special chars in query params  are not escaped when making API calls 

Example code

```
service.list({ is_jurisdiction: true, attribute: 'card_status:needs_card' });
```

Before the string was being escaped when making the API call e.g `https://opensrp-stage.smartregister.org/opensrp/rest/location?is_jurisdiction=true&attribute=card_status%3Aneeds_card'`

Now that is resolved and the result is `https://opensrp-stage.smartregister.org/opensrp/rest/location?is_jurisdiction=true&attribute=card_status:needs_card'`