### PR TITLE
Enhance planform routes

### DIFF
--- a/packages/opensrp-plans/src/components/NewPlan/index.tsx
+++ b/packages/opensrp-plans/src/components/NewPlan/index.tsx
@@ -9,9 +9,10 @@ import {
   defaultCommonProps,
   defaultPropsForPlanForm,
   PropsForPlanForm,
+  redirectPathGetter,
 } from '../../helpers/common';
 import { CREATE_PLAN } from '../../lang';
-import { PLANS_LIST_VIEW_URL } from '../../constants';
+import { DRAFT_PLANS_LIST_VIEW_URL } from '../../constants';
 import {
   defaultEnvConfig,
   getFormActivities,
@@ -19,6 +20,7 @@ import {
   InterventionType,
   planActivities,
 } from '@opensrp/plan-form-core';
+import { useHistory } from 'react-router';
 
 type CreatePlanViewProps = CommonProps & PropsForPlanForm;
 
@@ -36,6 +38,7 @@ const defaultProps = {
 const CreatePlanView = (props: CreatePlanViewProps) => {
   const { envConfigs, baseURL, hiddenFields } = props;
   const pageTitle = CREATE_PLAN;
+  const history = useHistory();
 
   const configs = {
     ...defaultEnvConfig,
@@ -48,13 +51,19 @@ const CreatePlanView = (props: CreatePlanViewProps) => {
     activities: processActivitiesDates(planActivitiesMap[InterventionType.SM]),
   };
 
+  /** called when user clicks on cancel on the plan form */
+  const clickHandler = () => {
+    history.push(DRAFT_PLANS_LIST_VIEW_URL);
+  };
+
   const planFormProps = {
     hiddenFields,
     initialValues,
     baseURL: baseURL,
-    redirectAfterAction: PLANS_LIST_VIEW_URL,
+    getRedirectPath: redirectPathGetter,
     allFormActivities: getFormActivities(planActivities, configs),
     envConfigs: configs,
+    onCancel: clickHandler,
   };
 
   return (

--- a/packages/opensrp-plans/src/components/NewPlan/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/components/NewPlan/tests/index.test.tsx
@@ -9,6 +9,7 @@ import { Helmet } from 'react-helmet';
 import { act } from 'react-dom/test-utils';
 import { CREATE_PLAN } from '../../../lang';
 import { PlanFormFieldsKeys } from '@opensrp/plan-form';
+import { DRAFT_PLANS_LIST_VIEW_URL } from '../../../constants';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetch = require('jest-fetch-mock');
@@ -40,6 +41,15 @@ describe('Create Plan Page', () => {
 
     // check if form is rendered on the page
     expect(wrapper.find('form')).toHaveLength(1);
+
+    wrapper.find('button#planform-cancel-button').simulate('click');
+
+    wrapper.update();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((wrapper.find('Router').props() as any).history.location.pathname).toEqual(
+      DRAFT_PLANS_LIST_VIEW_URL
+    );
   });
 
   it('planForm gets configured', () => {

--- a/packages/opensrp-plans/src/components/UpdatePlan/index.tsx
+++ b/packages/opensrp-plans/src/components/UpdatePlan/index.tsx
@@ -2,7 +2,7 @@
  */
 import { RouteParams } from '../../helpers/types';
 import React, { useEffect, useState } from 'react';
-import { RouteComponentProps } from 'react-router';
+import { RouteComponentProps, useHistory } from 'react-router';
 import { Layout, PageHeader } from 'antd';
 import planReducer, {
   fetchPlanDefinitions,
@@ -20,17 +20,19 @@ import {
   defaultCommonProps,
   defaultPropsForPlanForm,
   PropsForPlanForm,
+  redirectMapping,
+  redirectPathGetter,
 } from '../../helpers/common';
 import {
   defaultEnvConfig,
   getFormActivities,
   planActivities,
   PlanDefinition,
+  PlanStatus,
 } from '@opensrp/plan-form-core';
 import { PlanLoading } from '../../helpers/utils';
 import { PlanForm, getPlanFormValues, propsForUpdatingPlans } from '@opensrp/plan-form';
 import { EDIT_PLAN } from '../../lang';
-import { PLANS_LIST_VIEW_URL } from '../../constants';
 
 /** register catalogue reducer */
 reducerRegistry.register(planReducerName, planReducer);
@@ -63,6 +65,7 @@ const EditPlanView = (props: EditViewTypes) => {
   const { plan, fetchPlan, serviceClass, baseURL, envConfigs, hiddenFields } = props;
   const { planId } = props.match.params;
   const [loading, setLoading] = useState<boolean>(!plan);
+  const history = useHistory();
 
   const { errorMessage, broken, handleBrokenPage } = useHandleBrokenPage();
 
@@ -93,15 +96,21 @@ const EditPlanView = (props: EditViewTypes) => {
     return <Resource404 />;
   }
 
+  /** called when user clicks on cancel on the plan form */
+  const cancelHandler = () => {
+    history.push(redirectMapping[plan.status as PlanStatus]);
+  };
+
   const initialValues = getPlanFormValues(plan);
   const productFormProps = {
     hiddenFields,
     baseURL,
     initialValues,
     ...propsForUpdatingPlans(plan.status),
-    redirectAfterAction: PLANS_LIST_VIEW_URL,
+    getRedirectPath: redirectPathGetter,
     allFormActivities: getFormActivities(planActivities, configs),
     envConfigs: configs,
+    onCancel: cancelHandler,
   };
 
   const pageTitle = EDIT_PLAN;

--- a/packages/opensrp-plans/src/components/UpdatePlan/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/components/UpdatePlan/tests/index.test.tsx
@@ -5,7 +5,7 @@ import { createBrowserHistory } from 'history';
 import { Router } from 'react-router';
 import { Provider } from 'react-redux';
 import { eusmPlans } from '../../../ducks/tests/fixtures';
-import { PLANS_LIST_VIEW_URL } from '../../../constants';
+import { ACTIVE_PLANS_LIST_VIEW_URL, PLANS_LIST_VIEW_URL } from '../../../constants';
 import { mount } from 'enzyme';
 import { Helmet } from 'react-helmet';
 import { act } from 'react-dom/test-utils';
@@ -74,6 +74,15 @@ describe('CreateEditProduct Page', () => {
 
     // check if form is rendered on the page
     expect(wrapper.find('form')).toHaveLength(1);
+
+    wrapper.find('button#planform-cancel-button').simulate('click');
+
+    wrapper.update();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((wrapper.find('Router').props() as any).history.location.pathname).toEqual(
+      ACTIVE_PLANS_LIST_VIEW_URL
+    );
   });
 
   it('planform is configured correctly', async () => {

--- a/packages/opensrp-plans/src/constants.tsx
+++ b/packages/opensrp-plans/src/constants.tsx
@@ -46,6 +46,10 @@ export const OPENSRP_PLANS = 'plans';
 export const PLANS_LIST_VIEW_URL = '/plans';
 export const PLANS_CREATE_VIEW_URL = '/plans/new';
 export const PLANS_EDIT_VIEW_URL = '/plans/edit';
+export const ACTIVE_PLANS_LIST_VIEW_URL = '/plans/active';
+export const DRAFT_PLANS_LIST_VIEW_URL = '/plans/draft';
+export const COMPLETE_PLANS_LIST_VIEW_URL = '/plans/complete';
+export const TRASH_PLANS_LIST_VIEW_URL = '/plans/trash';
 export const HOME_URL = '/';
 
 // other constants

--- a/packages/opensrp-plans/src/helpers/common.ts
+++ b/packages/opensrp-plans/src/helpers/common.ts
@@ -1,6 +1,12 @@
-import { defaultEnvConfig, EnvConfig } from '@opensrp/plan-form-core';
+import { defaultEnvConfig, EnvConfig, PlanStatus } from '@opensrp/plan-form-core';
 import { PlanFormProps } from '@opensrp/plan-form/dist/types';
-import { OPENSRP_API_BASE_URL } from '../constants';
+import {
+  ACTIVE_PLANS_LIST_VIEW_URL,
+  COMPLETE_PLANS_LIST_VIEW_URL,
+  DRAFT_PLANS_LIST_VIEW_URL,
+  OPENSRP_API_BASE_URL,
+  TRASH_PLANS_LIST_VIEW_URL,
+} from '../constants';
 
 /** props that are common to majority of exported components */
 export interface CommonProps {
@@ -18,4 +24,21 @@ export type PropsForPlanForm = Pick<PlanFormProps, 'hiddenFields'>;
 
 export const defaultPropsForPlanForm = {
   hiddenFields: [],
+};
+
+/** mapping of plan statuses to the redirection urls for the plan form */
+export const redirectMapping = {
+  [PlanStatus.DRAFT]: DRAFT_PLANS_LIST_VIEW_URL,
+  [PlanStatus.ACTIVE]: ACTIVE_PLANS_LIST_VIEW_URL,
+  [PlanStatus.COMPLETE]: COMPLETE_PLANS_LIST_VIEW_URL,
+  [PlanStatus.RETIRED]: TRASH_PLANS_LIST_VIEW_URL,
+};
+
+/** plan form will redirect to the returned path after form submission based on the plan status
+ *
+ * @param {PlanStatus} status - status of the plan
+ * @returns {string} - the redirect url
+ */
+export const redirectPathGetter = (status: PlanStatus = PlanStatus.DRAFT) => {
+  return redirectMapping[status];
 };

--- a/packages/opensrp-plans/src/helpers/tests/utils.test.tsx
+++ b/packages/opensrp-plans/src/helpers/tests/utils.test.tsx
@@ -1,8 +1,15 @@
-import { SORT_BY_EFFECTIVE_PERIOD_START_FIELD } from '../../constants';
+import {
+  ACTIVE_PLANS_LIST_VIEW_URL,
+  COMPLETE_PLANS_LIST_VIEW_URL,
+  DRAFT_PLANS_LIST_VIEW_URL,
+  SORT_BY_EFFECTIVE_PERIOD_START_FIELD,
+  TRASH_PLANS_LIST_VIEW_URL,
+} from '../../constants';
 import * as planDefinitionFixtures from '../../ducks/tests/fixtures';
-import { InterventionType, PlanDefinition } from '@opensrp/plan-form-core';
+import { InterventionType, PlanDefinition, PlanStatus } from '@opensrp/plan-form-core';
 import * as fixtures from '../../ducks/tests/fixtures';
 import { descendingOrderSort, isPlanDefinitionOfType, getPlanType } from '../utils';
+import { redirectPathGetter } from '../common';
 
 describe('helpers/utils', () => {
   beforeEach(() => {
@@ -56,5 +63,11 @@ describe('helpers/utils', () => {
     expect(result).toBeFalsy();
     result = isPlanDefinitionOfType(sampleIRSPlan, InterventionType.IRS);
     expect(result).toBeTruthy();
+  });
+  it('tests redirectGetter util', () => {
+    expect(redirectPathGetter(PlanStatus.DRAFT)).toEqual(DRAFT_PLANS_LIST_VIEW_URL);
+    expect(redirectPathGetter(PlanStatus.ACTIVE)).toEqual(ACTIVE_PLANS_LIST_VIEW_URL);
+    expect(redirectPathGetter(PlanStatus.COMPLETE)).toEqual(COMPLETE_PLANS_LIST_VIEW_URL);
+    expect(redirectPathGetter(PlanStatus.RETIRED)).toEqual(TRASH_PLANS_LIST_VIEW_URL);
   });
 });

--- a/packages/plan-form/README.md
+++ b/packages/plan-form/README.md
@@ -52,11 +52,17 @@ _Optional_(`(payload) => boolean`)
 
 hook called before the submitting is initiated, return boolean to indicate if submitting should proceed
 
-#### redirectAfterAction
+#### getRedirectPath
 
-_Optional_(`string`)
+**required**(`(planStatus) => string`)
 
-Takes user the defined route upon successfully submitting payload to api
+callback to get the path to redirect after successfully form submission
+
+#### onCancel
+
+**required**(`() => void`)
+
+callback called once user clicks on cancel in the plan form
 
 #### allFormActivities
 


### PR DESCRIPTION
Support redirecting to different routes in plan-form, 
this is in order to support the different plan listing pages, such that creating a  plan will take the user to the list page of the plans of the same status