### PR TITLE
Missions sidemenu tweaks

### DIFF
--- a/client/src/components/page/Sidebar/index.tsx
+++ b/client/src/components/page/Sidebar/index.tsx
@@ -11,7 +11,6 @@ import {
   LOCATIONS_UNIT,
   LOCATIONS_UNIT_GROUP,
   LOCATIONS_UNIT_GROUP_SET,
-  PLANS,
   PRODUCT_CATALOGUE,
   TEAMS,
   URL_ADMIN,
@@ -25,6 +24,7 @@ import {
   DRAFT,
   COMPLETE,
   TRASH,
+  MISSIONS,
 } from '../../../constants';
 import { CATALOGUE_LIST_VIEW_URL } from '@opensrp/product-catalogue';
 import { ENABLE_PLANS, ENABLE_PRODUCT_CATALOGUE } from '../../../configs/env';
@@ -60,6 +60,30 @@ export const SidebarComponent: React.FC<SidebarProps> = (props: SidebarProps) =>
         </Link>
       </div>
       <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" className="menu-dark">
+        {ENABLE_PLANS && (
+          <Menu.SubMenu key="missions" icon={<DashboardOutlined />} title={MISSIONS}>
+            <Menu.Item key="plans-active">
+              <Link to={ACTIVE_PLANS_LIST_VIEW_URL} className="admin-link">
+                {ACTIVE}
+              </Link>
+            </Menu.Item>
+            <Menu.Item key="plans-draft">
+              <Link to={DRAFT_PLANS_LIST_VIEW_URL} className="admin-link">
+                {DRAFT}
+              </Link>
+            </Menu.Item>
+            <Menu.Item key="plans-complete">
+              <Link to={COMPLETE_PLANS_LIST_VIEW_URL} className="admin-link">
+                {COMPLETE}
+              </Link>
+            </Menu.Item>
+            <Menu.Item key="plans-trash">
+              <Link to={TRASH_PLANS_LIST_VIEW_URL} className="admin-link">
+                {TRASH}
+              </Link>
+            </Menu.Item>
+          </Menu.SubMenu>
+        )}
         <Menu.SubMenu key="admin" icon={<DashboardOutlined />} title={ADMIN}>
           {roles && roles.includes('ROLE_EDIT_KEYCLOAK_USERS') && (
             <Menu.SubMenu key="users" title={USERS}>
@@ -81,30 +105,6 @@ export const SidebarComponent: React.FC<SidebarProps> = (props: SidebarProps) =>
                 {PRODUCT_CATALOGUE}
               </Link>
             </Menu.Item>
-          )}
-          {ENABLE_PLANS && (
-            <Menu.SubMenu key="admin-locations" title={PLANS}>
-              <Menu.Item key="plans-active">
-                <Link to={ACTIVE_PLANS_LIST_VIEW_URL} className="admin-link">
-                  {ACTIVE}
-                </Link>
-              </Menu.Item>
-              <Menu.Item key="plans-draft">
-                <Link to={DRAFT_PLANS_LIST_VIEW_URL} className="admin-link">
-                  {DRAFT}
-                </Link>
-              </Menu.Item>
-              <Menu.Item key="plans-complete">
-                <Link to={COMPLETE_PLANS_LIST_VIEW_URL} className="admin-link">
-                  {COMPLETE}
-                </Link>
-              </Menu.Item>
-              <Menu.Item key="plans-trash">
-                <Link to={TRASH_PLANS_LIST_VIEW_URL} className="admin-link">
-                  {TRASH}
-                </Link>
-              </Menu.Item>
-            </Menu.SubMenu>
           )}
           <Menu.SubMenu key="admin-locations" title={LOCATIONS}>
             <Menu.Item key="locations-unit">{LOCATIONS_UNIT}</Menu.Item>

--- a/client/src/constants.tsx
+++ b/client/src/constants.tsx
@@ -16,6 +16,7 @@ export const TRASH = 'Trash';
 export const LOCATIONS = 'Locations';
 export const USERS = 'Users';
 export const ADMIN = 'Admin';
+export const MISSIONS = 'Missions';
 
 // URLs
 export const URL_EXPRESS_LOGIN = '/login';


### PR DESCRIPTION
Fix: #165 
Match Missions/Plans menu with Mockup. I've consistently named plans knowing  this will be translated in the future on a project basis
Here is the comment 
https://github.com/OpenSRP/web/issues/165#issuecomment-742817959
Current UI
![Screenshot from 2020-12-11 10-19-25](https://user-images.githubusercontent.com/16018123/101875702-295f9900-3b9c-11eb-846a-7879b335a9c9.png)
