### PR TITLE
fix extra fields initial state when editing location unit

### DIFF
--- a/packages/location-management/src/components/LocationUnitAddEdit/index.tsx
+++ b/packages/location-management/src/components/LocationUnitAddEdit/index.tsx
@@ -123,10 +123,7 @@ export const LocationUnitAddEdit: React.FC<Props> = (props: Props) => {
         .list()
         .then((response: LocationUnit) => {
           setLocationUnitDetail({
-            name: response.properties.name,
-            parentId: response.properties.parentId,
-            status: response.properties.status,
-            externalId: response.properties.externalId,
+            ...response.properties,
             locationTags: response.locationTags?.map((loc) => loc.id),
             geometry: JSON.stringify(response.geometry),
             type: response.type,


### PR DESCRIPTION
fix extra fields initial state when editing a location by appending all of the location properties into the initial formfields instead of picking one by one

Close #337 