### PR TITLE
Solve 400 error when editing user

### DIFF
--- a/packages/keycloak-user-management/src/components/Credentials/index.tsx
+++ b/packages/keycloak-user-management/src/components/Credentials/index.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import { makeAPIStateSelector } from '@opensrp/store';
 import { KeycloakService } from '@opensrp/keycloak-service';
+import { history } from '@onaio/connected-reducer-registry';
 import '../../index.css';
 import {
   KEYCLOAK_URL_USERS,
@@ -109,7 +110,7 @@ export const submitForm = (
     })
     .then(() => {
       sendSuccessNotification(CREDENTIALS_UPDATED_SUCCESSFULLY);
-      useHistory().push(URL_USER);
+      history.push(URL_USER);
     })
     .catch((_: Error) => {
       sendErrorNotification(ERROR_OCCURED);

--- a/packages/keycloak-user-management/src/components/Credentials/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/Credentials/tests/index.test.tsx
@@ -19,6 +19,7 @@ import {
   KeycloakUser,
 } from '../../../ducks/user';
 import { URL_USER, ERROR_OCCURED, CREDENTIALS_UPDATED_SUCCESSFULLY } from '../../../constants';
+import { history as registryHistory } from '@onaio/connected-reducer-registry';
 
 reducerRegistry.register(keycloakUsersReducerName, keycloakUsersReducer);
 
@@ -94,6 +95,7 @@ describe('components/Credentials', () => {
 
   it('adds user credentials correctly', async () => {
     const mockNotificationSuccess = jest.spyOn(notifications, 'sendSuccessNotification');
+    const historyPushMock = jest.spyOn(registryHistory, 'push');
 
     const wrapper = mount(
       <Provider store={store}>
@@ -141,6 +143,7 @@ describe('components/Credentials', () => {
       },
     ]);
     expect(mockNotificationSuccess).toHaveBeenCalledWith(CREDENTIALS_UPDATED_SUCCESSFULLY);
+    expect(historyPushMock).toHaveBeenCalledWith('/admin/users/list');
     wrapper.unmount();
   });
 

--- a/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
@@ -115,8 +115,11 @@ const UserForm: React.FC<UserFormProps> = (props: UserFormProps) => {
    * the form fields initial values will not change if props.initiaValues is updated
    * **/
   React.useEffect(() => {
-    form.setFieldsValue(initialValues);
-  }, [form, initialValues]);
+    form.setFieldsValue({
+      ...initialValues,
+      active: !!practitioner && practitioner.active,
+    });
+  }, [form, initialValues, practitioner]);
 
   return (
     <Row className="layout-content">
@@ -128,7 +131,10 @@ const UserForm: React.FC<UserFormProps> = (props: UserFormProps) => {
         <Form
           {...layout}
           form={form}
-          initialValues={initialValues}
+          initialValues={{
+            ...initialValues,
+            active: !!practitioner && practitioner.active,
+          }}
           onFinish={(values) => {
             submitForm(
               {
@@ -185,7 +191,7 @@ const UserForm: React.FC<UserFormProps> = (props: UserFormProps) => {
               label="Mark as Practitioner"
               valuePropName="checked"
             >
-              <Switch defaultChecked={!!practitioner && practitioner.active} />
+              <Switch />
             </Form.Item>
           ) : null}
           {initialValues.id !== extraData.user_id ? (

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/__snapshots__/index.test.tsx.snap
@@ -60,6 +60,7 @@ Object {
               "mapRoles": false,
               "view": false,
             },
+            "active": false,
             "createdTimestamp": undefined,
             "disableableCredentialTypes": Array [],
             "email": "",
@@ -285,9 +286,10 @@ Object {
   >
     <Memo
       update={3}
+      value={false}
     >
       <Switch
-        defaultChecked={false}
+        checked={false}
         id="active"
         onChange={[Function]}
       />
@@ -320,9 +322,10 @@ Object {
   >
     <Memo
       update={3}
+      value={true}
     >
       <Switch
-        defaultChecked={true}
+        checked={true}
         id="active"
         onChange={[Function]}
       />

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -15,6 +15,18 @@ jest.mock('@opensrp/notifications', () => ({
   ...jest.requireActual('@opensrp/notifications'),
 }));
 
+const mockV4 = '0b3a3311-6f5a-40dd-95e5-008001acebe1';
+
+jest.mock('uuid', () => {
+  const v4 = () => mockV4;
+
+  return {
+    __esModule: true,
+    ...jest.requireActual('uuid'),
+    v4,
+  };
+});
+
 describe('forms/utils/fetchRequiredActions', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -249,6 +261,26 @@ describe('forms/utils/submitForm', () => {
     await act(async () => {
       await flushPromises();
     });
+    expect(fetch.mock.calls[0]).toEqual([
+      `https://opensrp-stage.smartregister.org/opensrp/rest/practitioner`,
+      {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        body: JSON.stringify({
+          active: true,
+          identifier: mockV4,
+          name: 'Jane Doe',
+          userId: keycloakUser.id,
+          username: 'janedoe@example.com',
+        }),
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer token',
+          'content-type': 'application/json;charset=UTF-8',
+        },
+        method: 'POST',
+      },
+    ]);
     expect(notificationSuccessMock).toHaveBeenCalledWith('Practitioner created successfully');
   });
 
@@ -271,6 +303,69 @@ describe('forms/utils/submitForm', () => {
     await act(async () => {
       await flushPromises();
     });
+    expect(fetch.mock.calls[0]).toEqual([
+      `https://opensrp-stage.smartregister.org/opensrp/rest/practitioner`,
+      {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        body: JSON.stringify({
+          active: true,
+          identifier: fixtures.practitioner1.identifier,
+          name: 'Jane Doe',
+          userId: keycloakUser.id,
+          username: 'janedoe@example.com',
+        }),
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer token',
+          'content-type': 'application/json;charset=UTF-8',
+        },
+        method: 'PUT',
+      },
+    ]);
+    expect(notificationSuccessMock).toHaveBeenCalledWith('Practitioner updated successfully');
+  });
+
+  it('calls API with userId if present in values', async () => {
+    const valuesCopy = {
+      ...values,
+      active: true,
+      id: keycloakUser.id,
+      userId: fixtures.practitioner1.userId,
+    };
+
+    createOrEditPractitioners(
+      accessToken,
+      opensrpBaseURL,
+      opensrpServiceClass,
+      valuesCopy,
+      fixtures.practitioner1,
+      true
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(fetch.mock.calls[0]).toEqual([
+      `https://opensrp-stage.smartregister.org/opensrp/rest/practitioner`,
+      {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        body: JSON.stringify({
+          active: true,
+          identifier: fixtures.practitioner1.identifier,
+          name: 'Jane Doe',
+          userId: fixtures.practitioner1.userId,
+          username: 'janedoe@example.com',
+        }),
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer token',
+          'content-type': 'application/json;charset=UTF-8',
+        },
+        method: 'PUT',
+      },
+    ]);
     expect(notificationSuccessMock).toHaveBeenCalledWith('Practitioner updated successfully');
   });
 

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -62,7 +62,7 @@ export const createOrEditPractitioners = (
     active: isEdit ? values.active : true,
     identifier: practitioner ? practitioner.identifier : v4(),
     name: `${values.firstName} ${values.lastName}`,
-    userId: values.id,
+    userId: values.userId || values.id,
     username: values.username,
   };
 
@@ -122,7 +122,10 @@ export const submitForm = (
           accessToken,
           opensrpBaseURL,
           opensrpServiceClass,
-          values,
+          {
+            ...values,
+            userId,
+          },
           practitioner,
           isEditing
         );


### PR DESCRIPTION
The practitioners endpoint was throwing 400. This was because userId attribute was not being submitted as part of the request payload. The switch toggle was also not being checked on loading the form when editing a user who is marked as practitioner