### PR TITLE
Display server response as notification error if upload form fails

### DIFF
--- a/packages/form-config/src/components/Antd/UploadForm/tests/index.test.tsx
+++ b/packages/form-config/src/components/Antd/UploadForm/tests/index.test.tsx
@@ -17,7 +17,6 @@ import { fixManifestFiles } from '../../../../ducks/tests/fixtures';
 import sampleFile from './sampleFile.json';
 import { act } from 'react-dom/test-utils';
 import * as notifications from '@opensrp/notifications';
-import { ERROR_OCCURRED } from '../../../../constants';
 
 /** register the reducers */
 reducerRegistry.register(filesReducerName, filesReducer);
@@ -238,7 +237,7 @@ describe('components/UploadForm', () => {
   });
 
   it('handles error if upload fails', async () => {
-    fetch.mockRejectOnce(() => Promise.reject('API has been hijacked by aliens'));
+    fetch.mockResponse('API has been hijacked by aliens', { status: 500 });
 
     const wrapper = mount(
       <Provider store={store}>
@@ -265,7 +264,7 @@ describe('components/UploadForm', () => {
     });
     wrapper.update();
 
-    expect(mockNotificationError).toHaveBeenCalledWith(ERROR_OCCURRED);
+    expect(mockNotificationError).toHaveBeenCalledWith('API has been hijacked by aliens');
     wrapper.unmount();
   });
 

--- a/packages/form-config/src/components/Antd/UploadForm/tests/utils.test.tsx
+++ b/packages/form-config/src/components/Antd/UploadForm/tests/utils.test.tsx
@@ -4,7 +4,6 @@ import { act } from 'react-dom/test-utils';
 import flushPromises from 'flush-promises';
 import fetch from 'jest-fetch-mock';
 import * as notifications from '@opensrp/notifications';
-import { ERROR_OCCURRED } from '../../../../constants';
 
 const mockNotificationError = jest.spyOn(notifications, 'sendErrorNotification');
 
@@ -65,7 +64,10 @@ describe('components/UploadForm/utils/submitForm', () => {
   });
 
   it('handles error if form creation fails', async () => {
-    fetch.mockRejectOnce(() => Promise.reject('API has been hijacked by aliens'));
+    fetch.mockResponse(
+      'Unknown error. Kindly confirm that the form does not already exist on the server',
+      { status: 500 }
+    );
 
     submitForm(values, accessToken, opensrpBaseURL, false, setSubmittingMock, setIfDoneMock);
 
@@ -73,7 +75,9 @@ describe('components/UploadForm/utils/submitForm', () => {
       await flushPromises();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith(ERROR_OCCURRED);
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'Unknown error. Kindly confirm that the form does not already exist on the server'
+    );
     expect(setIfDoneMock).not.toHaveBeenCalled();
     expect(setSubmittingMock.mock.calls[0][0]).toEqual(true);
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);

--- a/packages/form-config/src/components/Antd/UploadForm/utils.tsx
+++ b/packages/form-config/src/components/Antd/UploadForm/utils.tsx
@@ -1,6 +1,6 @@
 import { UploadFileFieldTypes, UploadFilePropTypes } from '.';
-import { OpenSRPService } from '@opensrp/server-service';
-import { OPENSRP_FORMS_ENDPOINT, ERROR_OCCURRED } from '../../../constants';
+import { HTTPError, OpenSRPService } from '@opensrp/server-service';
+import { OPENSRP_FORMS_ENDPOINT } from '../../../constants';
 import { sendErrorNotification } from '@opensrp/notifications';
 
 /**
@@ -59,8 +59,8 @@ export const submitForm = (
     .then(() => {
       setIfDoneHere(true);
     })
-    .catch((_: Error) => {
-      sendErrorNotification(ERROR_OCCURRED);
+    .catch((err: HTTPError) => {
+      sendErrorNotification(err.description);
     })
     .finally(() => {
       setSubmitting(false);


### PR DESCRIPTION
Addresses #358

Show server response if the API responds with an error when uploading a form