### PR TITLE
Service point lat long

### DIFF
--- a/app/src/App/utils.tsx
+++ b/app/src/App/utils.tsx
@@ -28,7 +28,7 @@ export const BaseProps = {
 
 export const newLocationUnitProps = {
   redirectAfterAction: URL_LOCATION_UNIT,
-  hidden: 'serviceTypes',
+  hidden: ['serviceType', 'latitude', 'longitude'],
 };
 
 export const editLocationProps = {

--- a/packages/inventory/src/containers/CreateServicePoint/index.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/index.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps } from 'react-router';
 import { CommonProps, defaultCommonProps } from '../../helpers/common';
 import { INVENTORY_SERVICE_POINT_LIST_VIEW } from '../../constants';
 import { LocationFormFields } from '@opensrp/location-management/dist/types/components/LocationForm/utils';
-import { disabledTreeNodesCallback } from '../../helpers/utils';
+import { commonHiddenFields, disabledTreeNodesCallback } from '../../helpers/utils';
 
 type ServicePointAddTypes = CommonProps & RouteComponentProps;
 
@@ -22,7 +22,7 @@ const ServicePointsAdd = (props: ServicePointAddTypes) => {
     ...restProps,
     openSRPBaseURL: baseURL,
     instance: FormInstances.EUSM,
-    hidden: ['extraFields', 'status', 'type', 'locationTags', 'externalId'],
+    hidden: commonHiddenFields,
     redirectAfterAction: INVENTORY_SERVICE_POINT_LIST_VIEW,
     disabled: ['isJurisdiction'],
     processInitialValues: (data: LocationFormFields) => ({ ...data, isJurisdiction: false }),

--- a/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
@@ -8,6 +8,7 @@ import { store } from '@opensrp/store';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import { act } from 'react-dom/test-utils';
+import { commonHiddenFields } from '../../../helpers/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetch = require('jest-fetch-mock');
@@ -65,13 +66,7 @@ describe('CreateServicePoint', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const initialValues = (locationFormProps as any).initialValues;
 
-    expect(locationFormProps.hidden).toEqual([
-      'extraFields',
-      'status',
-      'type',
-      'locationTags',
-      'externalId',
-    ]);
+    expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
     expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
   });

--- a/packages/inventory/src/containers/EditServicePoint/index.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/index.tsx
@@ -3,7 +3,7 @@ import { INVENTORY_SERVICE_POINT_LIST_VIEW } from '../../constants';
 import { CommonProps, defaultCommonProps } from '../../helpers/common';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
-import { disabledTreeNodesCallback } from '../../helpers/utils';
+import { commonHiddenFields, disabledTreeNodesCallback } from '../../helpers/utils';
 
 type ServicePointAddTypes = CommonProps & RouteComponentProps<LocationRouteProps>;
 
@@ -21,7 +21,7 @@ const ServicePointEdit = (props: ServicePointAddTypes) => {
     ...restProps,
     openSRPBaseURL: baseURL,
     instance: FormInstances.EUSM,
-    hidden: ['extraFields', 'status', 'type', 'locationTags', 'externalId'],
+    hidden: commonHiddenFields,
     redirectAfterAction: INVENTORY_SERVICE_POINT_LIST_VIEW,
     disabled: ['isJurisdiction'],
     disabledTreeNodesCallback,

--- a/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
@@ -9,6 +9,7 @@ import { Router } from 'react-router';
 import { store } from '@opensrp/store';
 import { act } from 'react-dom/test-utils';
 import { authenticateUser } from '@onaio/session-reducer';
+import { commonHiddenFields } from '../../../helpers/utils';
 
 const history = createBrowserHistory();
 
@@ -68,13 +69,7 @@ describe('CreateServicePoint', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const initialValues = (locationFormProps as any).initialValues;
 
-    expect(locationFormProps.hidden).toEqual([
-      'extraFields',
-      'status',
-      'type',
-      'locationTags',
-      'externalId',
-    ]);
+    expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
     expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
   });

--- a/packages/inventory/src/helpers/utils.tsx
+++ b/packages/inventory/src/helpers/utils.tsx
@@ -48,3 +48,14 @@ export const CardTitle = ({ IconRender = null, text = '' }: CardTitleProps) => (
 export const disabledTreeNodesCallback = (node: TreeNode) => {
   return node.model.node.attributes.geographicLevel !== COMMUNE_GEOGRAPHIC_LEVEL;
 };
+
+/** location form fields that are hidden for service point creation and editing in EUSM */
+export const commonHiddenFields = [
+  'extraFields',
+  'status',
+  'type',
+  'locationTags',
+  'externalId',
+  'isJurisdiction',
+  'geometry',
+];

--- a/packages/location-management/src/components/EditLocationUnit/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/location-management/src/components/EditLocationUnit/tests/__snapshots__/index.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EditLocationUnit renders correctly when location is jurisdiction: form rendered 1`] = `"InstanceIdusernameParentNameStatusActiveInactiveLocation categoryService pointJurisdictionTypeTypeSelect the service point typeExternal IDGeometryUnit group23 SaveCancel"`;
+exports[`EditLocationUnit renders correctly when location is jurisdiction: form rendered 1`] = `"InstanceIdusernameParentNameStatusActiveInactiveLocation categoryService pointJurisdictionTypeTypeSelect the service point typeExternal IDGeometryLatitudeLongitudeUnit group23 SaveCancel"`;

--- a/packages/location-management/src/components/LocationForm/index.tsx
+++ b/packages/location-management/src/components/LocationForm/index.tsx
@@ -47,6 +47,10 @@ import {
   UNIT_GROUP_LABEL,
   USERNAME_LABEL,
   SERVICE_TYPE_PLACEHOLDER,
+  LONGITUDE_PLACEHOLDER,
+  LATITUDE_LABEL,
+  LATITUDE_PLACEHOLDER,
+  LONGITUDE_LABEL,
 } from '../../lang';
 import { CustomTreeSelect, CustomTreeSelectProps } from './CustomTreeSelect';
 import { TreeNode } from '../../ducks/locationHierarchy/types';
@@ -331,20 +335,20 @@ const LocationForm = (props: LocationFormProps) => {
             id="latitude"
             hidden={isHidden('latitude')}
             name="latitude"
-            label={'Latitude'}
+            label={LATITUDE_LABEL}
             rules={validationRules.latitude}
           >
-            <Input disabled={disabled.includes('latitude')} placeholder={''} />
+            <Input disabled={disabled.includes('latitude')} placeholder={LATITUDE_PLACEHOLDER} />
           </FormItem>
 
           <FormItem
             id="longitude"
             hidden={isHidden('longitude')}
             name="longitude"
-            label={'Longitude'}
+            label={LONGITUDE_LABEL}
             rules={validationRules.longitude}
           >
-            <Input disabled={disabled.includes('longitude')} placeholder={''} />
+            <Input disabled={disabled.includes('longitude')} placeholder={LONGITUDE_PLACEHOLDER} />
           </FormItem>
 
           <FormItem

--- a/packages/location-management/src/components/LocationForm/index.tsx
+++ b/packages/location-management/src/components/LocationForm/index.tsx
@@ -8,6 +8,7 @@ import {
   generateLocationUnit,
   getLocationTagOptions,
   getServiceTypeOptions,
+  handleGeoFieldsChangeFactory,
   LocationFormFields,
   ServiceTypeSetting,
   validationRules,
@@ -159,6 +160,8 @@ const LocationForm = (props: LocationFormProps) => {
     return <Redirect to={redirectAfterAction} />;
   }
 
+  const geoFieldsChangeHandler = handleGeoFieldsChangeFactory(form);
+
   return (
     <div className="location-form form-container">
       <Form
@@ -167,6 +170,7 @@ const LocationForm = (props: LocationFormProps) => {
         name="location-form"
         scrollToFirstError
         initialValues={initialValues}
+        onValuesChange={geoFieldsChangeHandler}
         /* tslint:disable-next-line jsx-no-lambda */
         onFinish={(values) => {
           const payload = generateLocationUnit(
@@ -321,6 +325,26 @@ const LocationForm = (props: LocationFormProps) => {
               rows={4}
               placeholder={GEOMETRY_PLACEHOLDER}
             />
+          </FormItem>
+
+          <FormItem
+            id="latitude"
+            hidden={isHidden('latitude')}
+            name="latitude"
+            label={'Latitude'}
+            rules={validationRules.latitude}
+          >
+            <Input disabled={disabled.includes('latitude')} placeholder={''} />
+          </FormItem>
+
+          <FormItem
+            id="longitude"
+            hidden={isHidden('longitude')}
+            name="longitude"
+            label={'Longitude'}
+            rules={validationRules.longitude}
+          >
+            <Input disabled={disabled.includes('longitude')} placeholder={''} />
           </FormItem>
 
           <FormItem

--- a/packages/location-management/src/components/LocationForm/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/location-management/src/components/LocationForm/tests/__snapshots__/index.test.tsx.snap
@@ -242,6 +242,31 @@ exports[`LocationForm renders correctly: isJurisdiction label 1`] = `
 </label>
 `;
 
+exports[`LocationForm renders correctly: latitude field 1`] = `
+<input
+  className="ant-input"
+  disabled={false}
+  id="location-form_latitude"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  placeholder=""
+  type="text"
+  value=""
+/>
+`;
+
+exports[`LocationForm renders correctly: latitude label 1`] = `
+<label
+  className=""
+  htmlFor="location-form_latitude"
+  title="Latitude"
+>
+  Latitude
+</label>
+`;
+
 exports[`LocationForm renders correctly: locationTags field 1`] = `
 <input
   aria-activedescendant="location-form_locationTags_list_0"
@@ -279,6 +304,31 @@ exports[`LocationForm renders correctly: locationTags label 1`] = `
   title="Unit group"
 >
   Unit group
+</label>
+`;
+
+exports[`LocationForm renders correctly: longitude field 1`] = `
+<input
+  className="ant-input"
+  disabled={false}
+  id="location-form_longitude"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  placeholder=""
+  type="text"
+  value=""
+/>
+`;
+
+exports[`LocationForm renders correctly: longitude label 1`] = `
+<label
+  className=""
+  htmlFor="location-form_longitude"
+  title="Longitude"
+>
+  Longitude
 </label>
 `;
 

--- a/packages/location-management/src/components/LocationForm/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/location-management/src/components/LocationForm/tests/__snapshots__/index.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`LocationForm renders correctly: latitude field 1`] = `
   onChange={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  placeholder=""
+  placeholder="E.g. -16.08306"
   type="text"
   value=""
 />
@@ -316,7 +316,7 @@ exports[`LocationForm renders correctly: longitude field 1`] = `
   onChange={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  placeholder=""
+  placeholder="E.g. 49.54933"
   type="text"
   value=""
 />

--- a/packages/location-management/src/components/LocationForm/tests/fixtures.ts
+++ b/packages/location-management/src/components/LocationForm/tests/fixtures.ts
@@ -50,6 +50,57 @@ export const location2 = ({
   // parentId is missing
 } as unknown) as LocationUnit;
 
+export const location3 = {
+  type: 'Feature',
+  id: '45e4bd97-fe11-458b-b481-294b7d7e8270',
+  geometry: {
+    type: 'Point',
+    coordinates: [49.52125, -16.78147],
+  },
+  properties: {
+    type: 'Water Point',
+    status: 'Active',
+    parentId: 'c38e0c1e-3d72-424b-ac37-29e8d3e82026',
+    name: 'Ambahoabe',
+    geographicLevel: 0,
+    version: 0,
+    AdminLevelTag: 'Commune',
+  },
+  serverVersion: 18481,
+} as LocationUnit;
+
+export const location4 = {
+  type: 'Feature',
+  id: '38a0a19b-f91e-4044-a8db-a4b62490bf27',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [17.4298095703125, 29.897805610155874],
+        [17.215576171875, 29.750070930806785],
+        [17.4957275390625, 29.3965337391284],
+        [17.9901123046875, 29.54000879252545],
+        [18.006591796874996, 29.79298413547051],
+        [17.4298095703125, 29.897805610155874],
+      ],
+    ],
+  },
+  properties: {
+    status: 'Active',
+    parentId: '03176924-6b3c-4b74-bccd-32afcceebabd',
+    name: 'MENABE',
+    geographicLevel: 1,
+    version: 0,
+  },
+  serverVersion: 2984,
+  locationTags: [
+    {
+      id: 2,
+      name: 'Region',
+    },
+  ],
+} as LocationUnit;
+
 export const generatedLocation1 = {
   id: 'b652b2f4-a95d-489b-9e28-4629746db96a',
   locationTags: [{ active: false, description: 'Sample description 2', id: 2, name: 'Sample 2' }],
@@ -88,7 +139,24 @@ export const generatedLocation2 = {
   syncStatus: 'Synced',
   type: 'Feature',
   locationTags: [{ id: 7, active: true, name: 'CHW ', description: 'The chw tags ' }],
-  geometry: [19.92919921875, 30.135626231134587],
+  geometry: { type: 'Point', coordinates: [19.92919921875, 30.135626231134587] },
+};
+
+export const generatedLocation4 = {
+  properties: {
+    geographicLevel: 1,
+    parentId: '03176924-6b3c-4b74-bccd-32afcceebabd',
+    name: 'MENABE',
+    name_en: 'MENABE',
+    status: 'Active',
+    serviceTypes: [{ name: 'School' }],
+    version: 0,
+  },
+  id: '38a0a19b-f91e-4044-a8db-a4b62490bf27',
+  syncStatus: 'Synced',
+  type: 'Feature',
+  locationTags: [{ id: 2, active: false, name: 'Sample 2', description: 'Sample description 2' }],
+  geometry: { type: 'Point', coordinates: [19.56, 34.56] },
 };
 
 export const expectedFormFields = {

--- a/packages/location-management/src/components/LocationForm/tests/fixtures.ts
+++ b/packages/location-management/src/components/LocationForm/tests/fixtures.ts
@@ -149,7 +149,7 @@ export const generatedLocation4 = {
     name: 'MENABE',
     name_en: 'MENABE',
     status: 'Active',
-    serviceTypes: [{ name: 'School' }],
+    type: 'School',
     version: 0,
   },
   id: '38a0a19b-f91e-4044-a8db-a4b62490bf27',

--- a/packages/location-management/src/components/LocationForm/tests/index.test.tsx
+++ b/packages/location-management/src/components/LocationForm/tests/index.test.tsx
@@ -216,11 +216,11 @@ describe('LocationForm', () => {
     });
 
     expect(wrapper.find('FormItem#longitude').text()).toMatchInlineSnapshot(
-      `"LongitudeLongitude should be a number"`
+      `"LongitudeOnly decimal values allowed"`
     );
 
     expect(wrapper.find('FormItem#latitude').text()).toMatchInlineSnapshot(
-      `"LatitudeLatitude should be a number"`
+      `"LatitudeOnly decimal values allowed"`
     );
 
     wrapper.unmount();
@@ -534,7 +534,7 @@ describe('LocationForm', () => {
     // simulate service type change
     // change service types
     formInstance.setFieldsValue({
-      serviceTypes: 'School',
+      serviceType: 'School',
     });
 
     wrapper.find('FormItem#latitude input').simulate('change', {

--- a/packages/location-management/src/components/LocationForm/tests/utils.test.tsx
+++ b/packages/location-management/src/components/LocationForm/tests/utils.test.tsx
@@ -15,6 +15,9 @@ import {
   locationUnitGroups,
   generatedLocation1,
   serviceTypeSettings,
+  location3,
+  location2,
+  location4,
 } from './fixtures';
 
 describe('locationForm.utils', () => {
@@ -37,6 +40,25 @@ describe('locationForm.utils', () => {
       instance: FormInstances.EUSM,
       isJurisdiction: false,
     });
+  });
+  it('generates long and lat correctly from locations geometry', () => {
+    const res1 = getLocationFormFields(location3);
+    expect(res1.geometry).toEqual('{"type":"Point","coordinates":[49.52125,-16.78147]}');
+    expect(res1.longitude).toEqual('49.52125');
+    expect(res1.latitude).toEqual('-16.78147');
+    // one without geometry
+    const res2 = getLocationFormFields(location2);
+    expect(res2.geometry).toBeUndefined();
+    expect(res2.longitude).toBeUndefined();
+    expect(res2.latitude).toBeUndefined();
+
+    // one whose geometry is not a point
+    const res3 = getLocationFormFields(location4);
+    expect(res3.geometry).toEqual(
+      '{"type":"Polygon","coordinates":[[[17.4298095703125,29.897805610155874],[17.215576171875,29.750070930806785],[17.4957275390625,29.3965337391284],[17.9901123046875,29.54000879252545],[18.006591796874996,29.79298413547051],[17.4298095703125,29.897805610155874]]]}'
+    );
+    expect(res3.longitude).toBeUndefined();
+    expect(res3.latitude).toBeUndefined();
   });
   it('is able to generate location unit from form', () => {
     const res = generateLocationUnit(expectedFormFields1, 'ComboBox', [locationUnitGroups[0]]);

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -295,7 +295,6 @@ export const validationRules = {
       };
     },
   ] as Rule[],
-
   serviceTypes: [
     ({ getFieldValue }) => {
       const instance = getFieldValue('instance');
@@ -309,11 +308,39 @@ export const validationRules = {
       };
     },
   ] as Rule[],
+  longitude: [
+    () => ({
+      validator(_, value) {
+        if (!value) {
+          return Promise.resolve();
+        }
+        return rejectIfNan(value, `Longitude should be a number`);
+      },
+    }),
+  ] as Rule[],
+  latitude: [
+    () => ({
+      validator(_, value) {
+        if (!value) {
+          return Promise.resolve();
+        }
+        return rejectIfNan(value, `Latitude should be a number`);
+      },
+    }),
+  ] as Rule[],
   extraFields: [
     {
       required: false,
     },
   ],
+};
+
+const rejectIfNan = (value: number, message: string) => {
+  if (isNaN(Number(value))) {
+    return Promise.reject(message);
+  } else {
+    return Promise.resolve();
+  }
 };
 
 /** gets location tag options for location form location tags select field

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -20,6 +20,7 @@ import {
   ERROR_LOCATION_TAGS_ARRAY,
   ERROR_LOCATION_CATEGORY_REQUIRED,
   ERROR_SERVICE_TYPES_REQUIRED,
+  LONGITUDE_LATITUDE_TYPE_ERROR,
 } from '../../lang';
 import { FormInstance } from 'antd/lib/form/hooks/useForm';
 
@@ -314,7 +315,7 @@ export const validationRules = {
         if (!value) {
           return Promise.resolve();
         }
-        return rejectIfNan(value, `Longitude should be a number`);
+        return rejectIfNan(value, LONGITUDE_LATITUDE_TYPE_ERROR);
       },
     }),
   ] as Rule[],
@@ -324,7 +325,7 @@ export const validationRules = {
         if (!value) {
           return Promise.resolve();
         }
-        return rejectIfNan(value, `Latitude should be a number`);
+        return rejectIfNan(value, LONGITUDE_LATITUDE_TYPE_ERROR);
       },
     }),
   ] as Rule[],

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -43,7 +43,7 @@ export interface LocationFormFields {
   locationTags?: number[];
   geometry?: string;
   isJurisdiction: boolean;
-  serviceTypes?: string;
+  serviceType?: string;
   extraFields: ExtraFields[];
   username?: string;
   latitude?: string;

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -336,7 +336,12 @@ export const validationRules = {
   ],
 };
 
-const rejectIfNan = (value: number, message: string) => {
+/** given a value retrun a rejected promise if value is not parseable as number
+ *
+ * @param value - value to parse into string
+ * @param message - error message to show
+ */
+const rejectIfNan = (value: string, message: string) => {
   if (isNaN(Number(value))) {
     return Promise.reject(message);
   } else {
@@ -415,6 +420,11 @@ export const getPointCoordinates = (geoText: string) => {
   return { longitude, latitude };
 };
 
+/** handles form values change , creates a values change handler that listens for
+ * changes to geometry, latitude and longitude and syncs changes across the 3 fields
+ *
+ * @param form - the form instance
+ */
 export const handleGeoFieldsChangeFactory = (form: FormInstance) => {
   return (changedValues: Partial<LocationFormFields>, allValues: LocationFormFields) => {
     /** location fields that could possible change */

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -9,7 +9,7 @@ import { Rule } from 'rc-field-form/lib/interface';
 import { TreeNode } from '../../ducks/locationHierarchy/types';
 import { DataNode } from 'rc-tree-select/lib/interface';
 import { v4 } from 'uuid';
-import { Geometry } from 'geojson';
+import { Geometry, Point } from 'geojson';
 import {
   ERROR_PARENTID_STRING,
   ERROR_NAME_STRING,
@@ -21,6 +21,7 @@ import {
   ERROR_LOCATION_CATEGORY_REQUIRED,
   ERROR_SERVICE_TYPES_REQUIRED,
 } from '../../lang';
+import { FormInstance } from 'antd/lib/form/hooks/useForm';
 
 export enum FormInstances {
   CORE = 'core',
@@ -40,10 +41,12 @@ export interface LocationFormFields {
   externalId?: string;
   locationTags?: number[];
   geometry?: string;
-  isJurisdiction?: boolean;
-  serviceType?: string;
+  isJurisdiction: boolean;
+  serviceTypes?: string;
   extraFields: ExtraFields[];
   username?: string;
+  latitude?: string;
+  longitude?: string;
 }
 
 interface BaseSetting {
@@ -103,6 +106,7 @@ export const getLocationFormFields = (
       ...commonValues,
     };
   }
+
   const {
     name,
     status,
@@ -112,12 +116,18 @@ export const getLocationFormFields = (
     type,
     ...restProperties
   } = location.properties;
+
+  // derive latitude and longitudes for point
+  const { geometry: geoObject } = location;
+  const geoJson = JSON.stringify(geoObject);
+  const { longitude, latitude } = getPointCoordinates(geoJson);
+
   const formFields = {
     ...defaultFormField,
     ...commonValues,
     id: location.id,
     locationTags: location.locationTags?.map((loc) => loc.id),
-    geometry: JSON.stringify(location.geometry),
+    geometry: geoJson,
     type: location.type,
     name,
     username,
@@ -126,6 +136,8 @@ export const getLocationFormFields = (
     externalId,
     serviceType: type,
     extraFields: Object.entries(restProperties).map(([key, val]) => ({ [key]: val })),
+    longitude,
+    latitude,
   };
 
   return formFields;

--- a/packages/location-management/src/components/NewLocationUnit/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/location-management/src/components/NewLocationUnit/tests/__snapshots__/index.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NewLocationUnit renders correctly when location is jurisdiction: form rendered 1`] = `"InstanceIdusernameParentSelect the parent locationNameStatusActiveInactiveLocation categoryService pointJurisdictionTypeTypeExternal IDGeometryUnit group Enter a location group nameSaveCancel"`;
+exports[`NewLocationUnit renders correctly when location is jurisdiction: form rendered 1`] = `"InstanceIdusernameParentSelect the parent locationNameStatusActiveInactiveLocation categoryService pointJurisdictionTypeTypeExternal IDGeometryLatitudeLongitudeUnit group Enter a location group nameSaveCancel"`;

--- a/packages/location-management/src/lang.ts
+++ b/packages/location-management/src/lang.ts
@@ -13,6 +13,7 @@ export const ERROR_LOCATION_TAGS_ARRAY = i18n.t('location unit groups must be an
 export const ERROR_GEOMETRY_STRING = i18n.t('Location unit groups must be a an string');
 export const ERROR_LOCATION_CATEGORY_REQUIRED = i18n.t('Location category is required');
 export const ERROR_SERVICE_TYPES_REQUIRED = i18n.t('Service types is required');
+export const LONGITUDE_LATITUDE_TYPE_ERROR = i18n.t('Only decimal values allowed');
 
 export const LOCATION_UNIT = i18n.t('Location Unit');
 export const LOCATION_UNIT_GROUP = i18n.t('Location Unit Group');
@@ -52,6 +53,8 @@ export const ENTER_A_LOCATION_GROUP_NAME_PLACEHOLDER = i18n.t('Enter a location 
 export const SAVING = i18n.t('Saving');
 export const SAVE = i18n.t('Save');
 export const SERVICE_TYPE_PLACEHOLDER = i18n.t('Select the service point type');
+export const LATITUDE_PLACEHOLDER = i18n.t('E.g. -16.08306');
+export const LONGITUDE_PLACEHOLDER = i18n.t('E.g. 49.54933');
 
 export const NAME = i18n.t('Name');
 export const STATUS = i18n.t('Status');
@@ -67,3 +70,5 @@ export const ACTIONS = i18n.t('Actions');
 export const EDIT = i18n.t('Edit');
 export const VIEW_DETAILS = i18n.t('View Details');
 export const DELETE = i18n.t('Delete');
+export const LATITUDE_LABEL = i18n.t('Latitude');
+export const LONGITUDE_LABEL = i18n.t('Longitude');


### PR DESCRIPTION
Add latitude and longitude fields for Add Edit structures

sync the geometry values across the 3 fields i.e .geometry, latitude and longitude,
How? by using an onValues change handler, one can observe for changes to any fields(in this case geometry, latitude, and longitude) and sync those changes to any other fields using form.setFieldsValue