### PR TITLE
Fix is jurisdiction status when editing service point

### DIFF
--- a/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
@@ -47,7 +47,7 @@ describe('CreateServicePoint', () => {
       },
       match: {
         isExact: true,
-        params: { id: '' },
+        params: { id: location1.id },
         path: `${INVENTORY_ADD_SERVICE_POINT}`,
         url: `${INVENTORY_ADD_SERVICE_POINT}`,
       },

--- a/packages/location-management/package.json
+++ b/packages/location-management/package.json
@@ -43,8 +43,9 @@
     "@opensrp/reducer-factory": "^0.0.11",
     "@opensrp/server-service": "^0.0.13",
     "cycle": "^1.0.3",
-    "tree-model": "^1.0.7",
-    "i18next": "^19.8.4"
+    "fast_array_intersect": "^1.1.0",
+    "i18next": "^19.8.4",
+    "tree-model": "^1.0.7"
   },
   "devDependencies": {
     "@onaio/redux-reducer-registry": "^0.0.9",

--- a/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
@@ -175,4 +175,40 @@ describe('EditLocationUnit', () => {
 
     expect(wrapper.text()).toMatchInlineSnapshot(`"ErrorAn error happenedGo BackBack Home"`);
   });
+
+  it('renders resource404 when location is not found', async () => {
+    fetch.once(JSON.stringify(null));
+    fetch.once(JSON.stringify(location1));
+    fetch.mockResponse(JSON.stringify([]));
+
+    const props = {
+      ...locationProps,
+      match: {
+        ...locationProps.match,
+        params: { id: 'unknown' },
+      },
+    };
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <EditLocationUnit {...props} />
+        </Router>
+      </Provider>
+    );
+
+    // loading page
+    expect(wrapper.text()).toMatchInlineSnapshot(`""`);
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    // resource not found
+    expect(wrapper.text()).toMatchInlineSnapshot(
+      'resource was not found',
+      `"404Sorry, the resource you requested for, does not existGo BackBack Home"`
+    );
+  });
 });

--- a/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
@@ -207,7 +207,6 @@ describe('EditLocationUnit', () => {
 
     // resource not found
     expect(wrapper.text()).toMatchInlineSnapshot(
-      'resource was not found',
       `"404Sorry, the resource you requested for, does not existGo BackBack Home"`
     );
   });

--- a/packages/location-management/src/components/LocationForm/index.tsx
+++ b/packages/location-management/src/components/LocationForm/index.tsx
@@ -149,6 +149,12 @@ const LocationForm = (props: LocationFormProps) => {
 
   const [form] = Form.useForm();
 
+  React.useEffect(() => {
+    form.setFieldsValue({
+      ...initialValues,
+    });
+  }, [form, initialValues]);
+
   const status = [
     { label: LOCATION_ACTIVE_STATUS_LABEL, value: LocationUnitStatus.ACTIVE },
     { label: LOCATION_INACTIVE_STATUS_LABEL, value: LocationUnitStatus.INACTIVE },

--- a/packages/location-management/src/components/LocationForm/tests/utils.test.tsx
+++ b/packages/location-management/src/components/LocationForm/tests/utils.test.tsx
@@ -60,6 +60,10 @@ describe('locationForm.utils', () => {
     expect(res3.longitude).toBeUndefined();
     expect(res3.latitude).toBeUndefined();
   });
+  it('derives correct isJurisdiction status from location unit', () => {
+    const res = getLocationFormFields({ ...location1, isJurisdiction: false });
+    expect(res).toEqual({ ...expectedFormFields1, isJurisdiction: false });
+  });
   it('is able to generate location unit from form', () => {
     const res = generateLocationUnit(expectedFormFields1, 'ComboBox', [locationUnitGroups[0]]);
     expect(res).toEqual(generatedLocation1);

--- a/packages/location-management/src/components/LocationForm/utils.tsx
+++ b/packages/location-management/src/components/LocationForm/utils.tsx
@@ -99,7 +99,7 @@ export const getLocationFormFields = (
 ): LocationFormFields => {
   const commonValues = {
     instance,
-    isJurisdiction,
+    isJurisdiction: location?.isJurisdiction ?? isJurisdiction,
   };
   if (!location) {
     return {

--- a/packages/location-management/src/ducks/location-units.ts
+++ b/packages/location-management/src/ducks/location-units.ts
@@ -12,6 +12,8 @@ import { Dictionary } from '@onaio/utils';
 import { Geometry } from 'geojson';
 import { createSelector } from 'reselect';
 import { Store } from 'redux';
+import { values } from 'lodash';
+import intersect from 'fast_array_intersect';
 
 /** interface for extra fields in location properties **/
 
@@ -116,6 +118,7 @@ export const getTotalLocationUnits = getTotalRecordsFactory(locationUnitsReducer
 export interface LocationUnitSelectFilters {
   searchQuery?: string;
   isJurisdiction?: boolean;
+  ids?: string[];
 }
 
 /** get the searchQuery from filter props
@@ -133,9 +136,32 @@ const getSearchQuery = (_: Partial<Store>, props: LocationUnitSelectFilters) => 
 const getIsJurisdiction = (_: Partial<Store>, props: LocationUnitSelectFilters) =>
   props.isJurisdiction;
 
+/** get the ids from filter props
+ *
+ * @param _ the store
+ * @param props - the filter props
+ */
+const getIds = (_: Partial<Store>, props: LocationUnitSelectFilters) => props.ids;
+
+/**
+ * non-memoized selector that returns the locationUnit array
+ *
+ * @param state - the store
+ */
+export const locationsByIdsSelector = (state: Partial<Store>): Dictionary<LocationUnit> => {
+  return (state as Dictionary)[locationUnitsReducerName].objectsById;
+};
+
+/**
+ * memoized selector to get the location units array from their ids object
+ */
+export const locationsArraySelector = createSelector(locationsByIdsSelector, (locationsByIds) =>
+  values(locationsByIds)
+);
+
 /** get locations depending on the isJurisdiction status */
 export const getLocationsIfJurisdiction = () =>
-  createSelector(getLocationUnitsArray, getIsJurisdiction, (locations, isJurisdiction) => {
+  createSelector(locationsArraySelector, getIsJurisdiction, (locations, isJurisdiction) => {
     if (isJurisdiction === undefined) {
       return locations;
     }
@@ -156,3 +182,31 @@ export const getLocationsBySearch = () =>
         loc.id === searchText
     );
   });
+
+/** get locations by their ids */
+export const getLocationByIds = () =>
+  createSelector(
+    locationsByIdsSelector,
+    locationsArraySelector,
+    getIds,
+    (locationsByIds, locations, ids) => {
+      if (ids === undefined) {
+        return locations;
+      }
+      return ids.map((id) => locationsByIds[id]);
+    }
+  );
+
+const locationsBySearch = getLocationsBySearch();
+const locationsByIds = getLocationByIds();
+
+/** main selector, combines the other selectors into one. */
+export const getLocationsByFilters = () =>
+  createSelector(
+    locationsBySearch,
+    locationsIfJurisdictionSelector,
+    locationsByIds,
+    (bySearch, byJurisdiction, byIds) => {
+      return intersect([bySearch, byJurisdiction, byIds], JSON.stringify);
+    }
+  );

--- a/packages/location-management/src/ducks/location-units.ts
+++ b/packages/location-management/src/ducks/location-units.ts
@@ -193,7 +193,12 @@ export const getLocationByIds = () =>
       if (ids === undefined) {
         return locations;
       }
-      return ids.map((id) => locationsByIds[id]);
+      const locationsOfInterest: LocationUnit[] = [];
+      ids.forEach((id) => {
+        const thisLocation = locationsByIds[id] as LocationUnit | undefined;
+        if (thisLocation) locationsOfInterest.push(thisLocation);
+      });
+      return locationsOfInterest;
     }
   );
 

--- a/packages/location-management/src/ducks/tests/location-units.test.ts
+++ b/packages/location-management/src/ducks/tests/location-units.test.ts
@@ -13,6 +13,8 @@ import {
   LocationUnit,
   getLocationsIfJurisdiction,
   getLocationsBySearch,
+  getLocationByIds,
+  getLocationsByFilters,
 } from '../location-units';
 import { locationUnit1, locationUnit2, locationUnit3 } from './fixtures';
 
@@ -59,6 +61,8 @@ describe('src/ducks/location-units', () => {
 describe('src/ducks/location-units.reselect', () => {
   const isJurisdictionSelector = getLocationsIfJurisdiction();
   const jurisdictionBySearch = getLocationsBySearch();
+  const jurisdictionsByIds = getLocationByIds();
+  const locationsSelector = getLocationsByFilters();
 
   beforeEach(() => {
     store.dispatch(removeLocationUnits());
@@ -69,6 +73,9 @@ describe('src/ducks/location-units.reselect', () => {
     expect(isJurisdictionSelector(store.getState(), { isJurisdiction: true })).toEqual([]);
     expect(jurisdictionBySearch(store.getState(), {})).toEqual([]);
     expect(jurisdictionBySearch(store.getState(), { searchQuery: 'tango' })).toEqual([]);
+    expect(jurisdictionsByIds(store.getState(), {})).toEqual([]);
+    expect(jurisdictionsByIds(store.getState(), { ids: ['tango'] })).toEqual([]);
+    expect(locationsSelector(store.getState(), {})).toEqual([]);
   });
 
   it('jurisdiction selector work correctly on non-empty state', () => {
@@ -79,6 +86,36 @@ describe('src/ducks/location-units.reselect', () => {
     ]);
     expect(isJurisdictionSelector(store.getState(), { isJurisdiction: false })).toEqual([
       { ...locationUnit3, isJurisdiction: false },
+    ]);
+  });
+
+  it('by id selectors', () => {
+    store.dispatch(fetchLocationUnits([locationUnit1] as LocationUnit[], true));
+    store.dispatch(fetchLocationUnits([locationUnit3] as LocationUnit[], false));
+    expect(jurisdictionsByIds(store.getState(), {})).toEqual([
+      { ...locationUnit1, isJurisdiction: true },
+      { ...locationUnit3, isJurisdiction: false },
+    ]);
+    expect(jurisdictionsByIds(store.getState(), { ids: [locationUnit1.id] })).toEqual([
+      { ...locationUnit1, isJurisdiction: true },
+    ]);
+  });
+
+  it('byFilter selector', () => {
+    store.dispatch(fetchLocationUnits([locationUnit1] as LocationUnit[], true));
+    store.dispatch(fetchLocationUnits([locationUnit3] as LocationUnit[], false));
+    expect(locationsSelector(store.getState(), {})).toEqual([
+      { ...locationUnit1, isJurisdiction: true },
+      { ...locationUnit3, isJurisdiction: false },
+    ]);
+    expect(locationsSelector(store.getState(), { isJurisdiction: false })).toEqual([
+      { ...locationUnit3, isJurisdiction: false },
+    ]);
+    expect(locationsSelector(store.getState(), { searchQuery: 'bodisatra' })).toEqual([
+      {
+        ...locationUnit3,
+        isJurisdiction: false,
+      },
     ]);
   });
 

--- a/packages/product-catalogue/src/components/ListView/index.tsx
+++ b/packages/product-catalogue/src/components/ListView/index.tsx
@@ -84,7 +84,7 @@ const ProductCatalogueList = (props: ProductCatalogueListTypes) => {
   });
 
   return (
-    <div className="content-section">
+    <div className="content-section product-catalogue">
       <Helmet>
         <title>{pageTitle}</title>
       </Helmet>

--- a/packages/product-catalogue/src/index.css
+++ b/packages/product-catalogue/src/index.css
@@ -70,7 +70,7 @@
   padding-right: 0;
 }
 
-.main-content__header {
+.product-catalogue .main-content__header {
   display: flex;
   justify-content: flex-end;
   align-items: center;


### PR DESCRIPTION
- Adds a single selector for location units that should work for all filters,
- Repopulate initial values when they change in the props
- initially get the isJurisdiction status from locationUnit otherwise fallback to passed in arg
- add a className to product-catalogue so that css can be scoped to only single component