### PR TITLE
Resolve bug Serial number field missing when editing an attractive item

### DIFF
--- a/packages/inventory/src/components/InventoryItemForm/index.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/index.tsx
@@ -180,10 +180,7 @@ const InventoryItemForm: React.FC<InventoryItemFormProps> = (props: InventoryIte
   const handleProductChange = (value: string) => {
     if (!isProductChanged) setProductChanged(true);
     const selected = products.find((product) => product.productName === value);
-
-    if (selected) {
-      setSelectedProduct(selected);
-    }
+    setSelectedProduct(selected);
   };
 
   const handleDeliveryDateChange = (date: moment.Moment | null, _: string) => {

--- a/packages/inventory/src/components/InventoryItemForm/index.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/index.tsx
@@ -157,7 +157,8 @@ const InventoryItemForm: React.FC<InventoryItemFormProps> = (props: InventoryIte
         accountabilityEndDate: accEndDate,
       });
     }
-  }, [selectedProduct, selectedDeliveryDate, form, isProductChanged, isDeliveryDateChanged]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProduct, selectedDeliveryDate, form]);
 
   /** Update form initial values when initialValues prop changes, without this
    * the form fields initial values will not change if props.initiaValues is updated

--- a/packages/inventory/src/containers/InventoryAddEdit/index.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/index.tsx
@@ -189,6 +189,7 @@ const InventoryAddEdit: React.FC<InventoryAddEditProps> = (props: InventoryAddEd
       poNumber: inventory.customProperties['PO Number'],
       quantity: inventory.value,
       productName: inventory.product?.productName,
+      serialNumber: inventory.serialNumber,
     };
   }
   const inventoryItemFormProps = {

--- a/packages/inventory/src/containers/InventoryAddEdit/tests/index.test.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/tests/index.test.tsx
@@ -206,6 +206,7 @@ describe('containers/InventoryAddEdit', () => {
         productName: undefined,
         quantity: '',
         unicefSection: undefined,
+        serialNumber: undefined,
       },
       inventoryID: undefined,
     });
@@ -437,11 +438,12 @@ describe('containers/InventoryAddEdit', () => {
       initialValues: {
         accountabilityEndDate: moment(fixtures.inventories[0].accountabilityEndDate),
         deliveryDate: moment(fixtures.inventories[0].deliveryDate),
-        donor: 'ADB',
-        poNumber: '101',
+        donor: fixtures.inventories[0].donor,
+        poNumber: fixtures.inventories[0].customProperties['PO Number'],
         productName: fixtures.inventories[0].product.productName,
         quantity: 1,
-        unicefSection: 'Health',
+        serialNumber: fixtures.inventories[0].serialNumber,
+        unicefSection: fixtures.inventories[0].customProperties['UNICEF section'],
       },
       inventoryID: fixtures.inventories[0]._id,
     });
@@ -640,11 +642,12 @@ describe('containers/InventoryAddEdit', () => {
       initialValues: {
         accountabilityEndDate: moment(fixtures.inventories[0].accountabilityEndDate),
         deliveryDate: moment(fixtures.inventories[0].deliveryDate),
-        donor: 'ADB',
-        poNumber: '101',
+        donor: fixtures.inventories[0].donor,
+        poNumber: fixtures.inventories[0].customProperties['PO Number'],
         productName: fixtures.inventories[0].product.productName,
         quantity: 1,
-        unicefSection: 'Health',
+        serialNumber: fixtures.inventories[0].serialNumber,
+        unicefSection: fixtures.inventories[0].customProperties['UNICEF section'],
       },
       inventoryID: fixtures.inventories[0]._id,
     });


### PR DESCRIPTION
Addresses #460 
Addresses #461 

Resolve bug Serial number field not displaying when editing an attractive item. The field was only displaying if both **Product** and **Delivery date** were changed hence it only worked when adding a new item 

Resolve bug Accountability end date field not being automatically calculated when editing an item. The  field was only being auto-calculated if both **Product** and **Delivery date** fields were changed, hence it only worked when adding a new item 