### PR TITLE
Service point QA fixes

### DIFF
--- a/app/src/App/utils.tsx
+++ b/app/src/App/utils.tsx
@@ -27,8 +27,8 @@ export const BaseProps = {
 };
 
 export const newLocationUnitProps = {
-  successURL: URL_LOCATION_UNIT,
-  cancelURL: URL_LOCATION_UNIT,
+  successURLGenerator: () => URL_LOCATION_UNIT,
+  cancelURLGenerator: () => URL_LOCATION_UNIT,
   hidden: ['serviceType', 'latitude', 'longitude'],
 };
 

--- a/app/src/App/utils.tsx
+++ b/app/src/App/utils.tsx
@@ -27,7 +27,8 @@ export const BaseProps = {
 };
 
 export const newLocationUnitProps = {
-  redirectAfterAction: URL_LOCATION_UNIT,
+  successURL: URL_LOCATION_UNIT,
+  cancelURL: URL_LOCATION_UNIT,
   hidden: ['serviceType', 'latitude', 'longitude'],
 };
 

--- a/packages/inventory/src/containers/CreateServicePoint/index.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import { FormInstances, NewLocationUnit } from '@opensrp/location-management';
+import { FormInstances, LocationUnit, NewLocationUnit } from '@opensrp/location-management';
 import { RouteComponentProps } from 'react-router';
 import { CommonProps, defaultCommonProps } from '../../helpers/common';
-import { INVENTORY_SERVICE_POINT_LIST_VIEW } from '../../constants';
+import {
+  INVENTORY_SERVICE_POINT_LIST_VIEW,
+  INVENTORY_SERVICE_POINT_PROFILE_VIEW,
+} from '../../constants';
 import { LocationFormFields } from '@opensrp/location-management/dist/types/components/LocationForm/utils';
 import { commonHiddenFields, disabledTreeNodesCallback } from '../../helpers/utils';
 
@@ -23,7 +26,9 @@ const ServicePointsAdd = (props: ServicePointAddTypes) => {
     openSRPBaseURL: baseURL,
     instance: FormInstances.EUSM,
     hidden: commonHiddenFields,
-    redirectAfterAction: INVENTORY_SERVICE_POINT_LIST_VIEW,
+    successURLGenerator: (payload?: LocationUnit) =>
+      `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload?.id}`, // todo if payload is missing
+    cancelURLGenerator: () => INVENTORY_SERVICE_POINT_LIST_VIEW,
     disabled: ['isJurisdiction'],
     processInitialValues: (data: LocationFormFields) => ({ ...data, isJurisdiction: false }),
     disabledTreeNodesCallback,

--- a/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
@@ -6,7 +6,7 @@ import { INVENTORY_ADD_SERVICE_POINT } from '../../../constants';
 import { authenticateUser } from '@onaio/session-reducer';
 import { store } from '@opensrp/store';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router';
+import { RouteComponentProps, Router } from 'react-router';
 import { act } from 'react-dom/test-utils';
 import { commonHiddenFields } from '../../../helpers/utils';
 
@@ -69,5 +69,13 @@ describe('CreateServicePoint', () => {
     expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
     expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
+
+    // test re-direction url on chancel
+    wrapper.find('button#location-form-cancel-button').simulate('click');
+    wrapper.update();
+
+    expect(
+      (wrapper.find('Router').props() as RouteComponentProps).history.location.pathname
+    ).toEqual('/inventory/list');
   });
 });

--- a/packages/inventory/src/containers/EditServicePoint/index.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/index.tsx
@@ -1,5 +1,10 @@
-import { FormInstances, EditLocationUnit, LocationRouteProps } from '@opensrp/location-management';
-import { INVENTORY_SERVICE_POINT_LIST_VIEW } from '../../constants';
+import {
+  FormInstances,
+  EditLocationUnit,
+  LocationRouteProps,
+  LocationUnit,
+} from '@opensrp/location-management';
+import { INVENTORY_SERVICE_POINT_PROFILE_VIEW } from '../../constants';
 import { CommonProps, defaultCommonProps } from '../../helpers/common';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -22,7 +27,10 @@ const ServicePointEdit = (props: ServicePointAddTypes) => {
     openSRPBaseURL: baseURL,
     instance: FormInstances.EUSM,
     hidden: commonHiddenFields,
-    redirectAfterAction: INVENTORY_SERVICE_POINT_LIST_VIEW,
+    successURLGenerator: (payload: LocationUnit) =>
+      `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload.id}`,
+    cancelURLGenerator: (payload: LocationUnit) =>
+      `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload.id}`,
     disabled: ['isJurisdiction'],
     disabledTreeNodesCallback,
   };

--- a/packages/inventory/src/containers/EditServicePoint/index.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/index.tsx
@@ -31,7 +31,7 @@ const ServicePointEdit = (props: ServicePointAddTypes) => {
       `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload.id}`,
     cancelURLGenerator: (payload: LocationUnit) =>
       `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload.id}`,
-    disabled: ['isJurisdiction'],
+    disabled: ['isJurisdiction', 'parentId'],
     disabledTreeNodesCallback,
   };
 

--- a/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
@@ -71,7 +71,7 @@ describe('CreateServicePoint', () => {
 
     expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
-    expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
+    expect(locationFormProps.disabled).toEqual(['isJurisdiction', 'parentId']);
 
     // test re-direction url on chancel
     wrapper.find('button#location-form-cancel-button').simulate('click');

--- a/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/EditServicePoint/tests/index.test.tsx
@@ -5,7 +5,7 @@ import { createBrowserHistory } from 'history';
 import { INVENTORY_ADD_SERVICE_POINT } from '../../../constants';
 import { location1 } from './fixtures';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router';
+import { RouteComponentProps, Router } from 'react-router';
 import { store } from '@opensrp/store';
 import { act } from 'react-dom/test-utils';
 import { authenticateUser } from '@onaio/session-reducer';
@@ -72,5 +72,13 @@ describe('CreateServicePoint', () => {
     expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
     expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
+
+    // test re-direction url on chancel
+    wrapper.find('button#location-form-cancel-button').simulate('click');
+    wrapper.update();
+
+    expect(
+      (wrapper.find('Router').props() as RouteComponentProps).history.location.pathname
+    ).toEqual('/inventory/profile/b652b2f4-a95d-489b-9e28-4629746db96a');
   });
 });

--- a/packages/location-management/src/components/EditLocationUnit/index.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/index.tsx
@@ -15,7 +15,7 @@ import { LocationFormProps, LocationForm } from '../LocationForm';
 import { FormInstances, getLocationFormFields } from '../LocationForm/utils';
 import { Spin, Row, Col } from 'antd';
 import { getUser } from '@onaio/session-reducer';
-import { EDIT_LOCATION_UNIT } from '../../lang';
+import { EDIT } from '../../lang';
 import { Helmet } from 'react-helmet';
 import reducerRegistry from '@onaio/redux-reducer-registry';
 
@@ -165,7 +165,7 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
     user: user.username,
     disabledTreeNodesCallback,
   };
-  const pageTitle = `${EDIT_LOCATION_UNIT} | ${thisLocation.properties.name}`;
+  const pageTitle = `${EDIT} > ${thisLocation.properties.name}`;
 
   return (
     <Row className="layout-content">

--- a/packages/location-management/src/components/EditLocationUnit/index.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/index.tsx
@@ -26,12 +26,14 @@ const locationsSelector = getLocationsByFilters();
 export type LocationRouteProps = { id: string };
 
 export interface EditLocationUnitProps
-  extends Pick<LocationFormProps, 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'>,
+  extends Pick<
+      LocationFormProps,
+      'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback' | 'successURLGenerator'
+    >,
     RouteComponentProps<LocationRouteProps> {
   openSRPBaseURL: string;
   instance: FormInstances;
-  successURL: string;
-  cancelURL: string;
+  cancelURLGenerator: (data: LocationUnit) => string;
 }
 
 const defaultEditLocationUnitProps = {
@@ -41,8 +43,8 @@ const defaultEditLocationUnitProps = {
   hidden: [],
   disabled: [],
   service: OpenSRPService,
-  successURL: '',
-  cancelURL: '',
+  successURLGenerator: () => '',
+  cancelURLGenerator: () => '',
 };
 
 /** renders page where user can Edit already created location unit
@@ -56,8 +58,8 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
     disabled,
     service,
     openSRPBaseURL,
-    successURL,
-    cancelURL,
+    cancelURLGenerator,
+    successURLGenerator,
     disabledTreeNodesCallback,
   } = props;
   const history = useHistory();
@@ -154,11 +156,14 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
   }
 
   const initialValues = getLocationFormFields(thisLocation, instance, isJurisdiction);
-  const cancelHandler = () => history.push(cancelURL);
+  const cancelHandler = () => {
+    const cancelURL = cancelURLGenerator(thisLocation);
+    history.push(cancelURL);
+  };
 
   const locationFormProps = {
     initialValues,
-    redirectAfterAction: successURL,
+    successURLGenerator,
     hidden,
     disabled,
     onCancel: cancelHandler,

--- a/packages/location-management/src/components/EditLocationUnit/index.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/index.tsx
@@ -26,13 +26,12 @@ const locationsSelector = getLocationsByFilters();
 export type LocationRouteProps = { id: string };
 
 export interface EditLocationUnitProps
-  extends Pick<
-      LocationFormProps,
-      'redirectAfterAction' | 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'
-    >,
+  extends Pick<LocationFormProps, 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'>,
     RouteComponentProps<LocationRouteProps> {
   openSRPBaseURL: string;
   instance: FormInstances;
+  successURL: string;
+  cancelURL: string;
 }
 
 const defaultEditLocationUnitProps = {
@@ -42,6 +41,8 @@ const defaultEditLocationUnitProps = {
   hidden: [],
   disabled: [],
   service: OpenSRPService,
+  successURL: '',
+  cancelURL: '',
 };
 
 /** renders page where user can Edit already created location unit
@@ -55,7 +56,8 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
     disabled,
     service,
     openSRPBaseURL,
-    redirectAfterAction,
+    successURL,
+    cancelURL,
     disabledTreeNodesCallback,
   } = props;
   const history = useHistory();
@@ -152,11 +154,11 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
   }
 
   const initialValues = getLocationFormFields(thisLocation, instance, isJurisdiction);
-  const cancelHandler = () => history.push(redirectAfterAction);
+  const cancelHandler = () => history.push(cancelURL);
 
   const locationFormProps = {
     initialValues,
-    redirectAfterAction,
+    redirectAfterAction: successURL,
     hidden,
     disabled,
     onCancel: cancelHandler,

--- a/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
@@ -3,7 +3,7 @@ import { EditLocationUnit } from '..';
 import React from 'react';
 import { store } from '@opensrp/store';
 import { createBrowserHistory } from 'history';
-import { Router } from 'react-router';
+import { RouteComponentProps, Router } from 'react-router';
 import { Provider } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import { removeLocationUnits } from '../../../ducks/location-units';
@@ -209,5 +209,43 @@ describe('EditLocationUnit', () => {
     expect(wrapper.text()).toMatchInlineSnapshot(
       `"404Sorry, the resource you requested for, does not existGo BackBack Home"`
     );
+  });
+
+  it('cancel url is used if passed', async () => {
+    fetch.once(JSON.stringify(null));
+    fetch.once(JSON.stringify(location1));
+    fetch.mockResponse(JSON.stringify([]));
+    const cancelURL = '/canceledURL';
+
+    const props = {
+      ...locationProps,
+      match: {
+        ...locationProps.match,
+        params: { id: location1.id },
+      },
+      cancelURL,
+    };
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <EditLocationUnit {...props} />
+        </Router>
+      </Provider>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    // simulate click on cancel button
+    wrapper.find('button#location-form-cancel-button').simulate('click');
+    wrapper.update();
+
+    // check url
+    expect(
+      (wrapper.find('Router').props() as RouteComponentProps).history.location.pathname
+    ).toEqual(cancelURL);
   });
 });

--- a/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
@@ -223,7 +223,7 @@ describe('EditLocationUnit', () => {
         ...locationProps.match,
         params: { id: location1.id },
       },
-      cancelURL,
+      cancelURLGenerator: () => cancelURL,
     };
 
     const wrapper = mount(

--- a/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/tests/index.test.tsx
@@ -92,10 +92,10 @@ describe('EditLocationUnit', () => {
     });
 
     const helmet = Helmet.peek();
-    expect(helmet.title).toEqual('Edit Location Unit | Kenya');
+    expect(helmet.title).toEqual('Edit > Kenya');
 
     // rendered page including title
-    expect(wrapper.find('h5').text()).toMatchInlineSnapshot(`"Edit Location Unit | Kenya"`);
+    expect(wrapper.find('h5').text()).toMatchInlineSnapshot(`"Edit > Kenya"`);
 
     expect(wrapper.find('LocationForm').text()).toMatchSnapshot('form rendered');
 

--- a/packages/location-management/src/components/LocationForm/index.tsx
+++ b/packages/location-management/src/components/LocationForm/index.tsx
@@ -14,7 +14,7 @@ import {
   validationRules,
 } from './utils';
 import { baseURL, SERVICE_TYPES_SETTINGS_ID, URL_LOCATION_UNIT } from '../../constants';
-import { LocationUnitStatus, LocationUnitTag } from '../../ducks/location-units';
+import { LocationUnit, LocationUnitStatus, LocationUnitTag } from '../../ducks/location-units';
 import { CustomSelect } from './CustomSelect';
 import { loadLocationTags, loadSettings, postPutLocationUnit } from '../../helpers/dataLoaders';
 import { OpenSRPService } from '@opensrp/react-utils';
@@ -61,7 +61,7 @@ const { Item: FormItem } = Form;
 export interface LocationFormProps
   extends Pick<CustomTreeSelectProps, 'disabledTreeNodesCallback'> {
   initialValues: LocationFormFields;
-  redirectAfterAction: string;
+  successURLGenerator: (payload: LocationUnit) => string;
   openSRPBaseURL: string;
   hidden: string[];
   disabled: string[];
@@ -72,12 +72,10 @@ export interface LocationFormProps
 
 const defaultProps = {
   initialValues: defaultFormField,
-  redirectAfterAction: URL_LOCATION_UNIT,
+  successURLGenerator: () => URL_LOCATION_UNIT,
   hidden: [],
   disabled: [],
-  onCancel: () => {
-    return;
-  },
+  onCancel: () => void 0,
   service: OpenSRPService,
   username: '',
   openSRPBaseURL: baseURL,
@@ -129,7 +127,7 @@ const tailLayout = {
 const LocationForm = (props: LocationFormProps) => {
   const {
     initialValues,
-    redirectAfterAction,
+    successURLGenerator,
     openSRPBaseURL,
     disabled,
     onCancel,
@@ -143,6 +141,7 @@ const LocationForm = (props: LocationFormProps) => {
   const [isSubmitting, setSubmitting] = useState<boolean>(false);
   const [selectedLocationTags, setLocationTags] = useState<LocationUnitTag[]>([]);
   const [selectedParentNode, setSelectedParentNode] = useState<TreeNode>();
+  const [generatedPayload, setGeneratedPayload] = useState<LocationUnit>();
 
   const isHidden = (fieldName: string) => hidden.includes(fieldName);
   const isDisabled = (fieldName: string) => disabled.includes(fieldName);
@@ -167,6 +166,7 @@ const LocationForm = (props: LocationFormProps) => {
   ];
   /** if plan is updated or saved redirect to plans page */
   if (areWeDoneHere) {
+    const redirectAfterAction = successURLGenerator(generatedPayload as LocationUnit);
     return <Redirect to={redirectAfterAction} />;
   }
 
@@ -202,6 +202,7 @@ const LocationForm = (props: LocationFormProps) => {
           postPutLocationUnit(payload, openSRPBaseURL, service, isEditMode, params)
             .then(() => {
               sendSuccessNotification(successMessage);
+              setGeneratedPayload(payload);
               setAreWeDoneHere(true);
             })
             .catch((err: Error) => {

--- a/packages/location-management/src/components/LocationForm/tests/index.test.tsx
+++ b/packages/location-management/src/components/LocationForm/tests/index.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { Router } from 'react-router';
+import { RouteComponentProps, Router } from 'react-router';
 import { LocationForm } from '..';
 import { defaultFormField, FormInstances, getLocationFormFields } from '../utils';
 import { createBrowserHistory } from 'history';
@@ -380,6 +380,117 @@ describe('LocationForm', () => {
       ],
     ]);
 
+    wrapper.unmount();
+  });
+
+  it('correctly redirects on submit', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    fetch.mockResponse(JSON.stringify([]));
+
+    const someMockURL = '/someURL';
+    const successURLGeneratorMock = jest.fn(() => someMockURL);
+
+    const wrapper = mount(
+      <Router history={history}>
+        <LocationForm successURLGenerator={successURLGeneratorMock} />
+      </Router>,
+      { attachTo: container }
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formInstance = (wrapper.find(Form).props() as any).form;
+
+    // change parent Id
+    formInstance.setFieldsValue({
+      parentId: '51',
+    });
+
+    // simulate active check to be inactive
+    wrapper
+      .find('FormItem#status input')
+      .last()
+      .simulate('change', {
+        target: { checked: true },
+      });
+
+    // set isJurisdiction to false
+    wrapper
+      .find('FormItem#isJurisdiction input')
+      .first()
+      .simulate('change', {
+        target: { checked: true },
+      });
+
+    // simulate type field change
+    wrapper
+      .find('FormItem#type input')
+      .simulate('change', { target: { name: 'type', value: 'Feature' } });
+
+    // simulate name change
+    wrapper
+      .find('FormItem#name input')
+      .simulate('change', { target: { name: 'name', value: 'area51' } });
+
+    // simulate service type change
+    // change service types
+    formInstance.setFieldsValue({
+      serviceType: 'School',
+    });
+
+    wrapper
+      .find('FormItem#externalId input')
+      .simulate('change', { target: { name: 'externalId', value: 'secret' } });
+
+    wrapper.find('FormItem#geometry textarea').simulate('change', {
+      target: { value: JSON.stringify([19.92919921875, 30.135626231134587]) },
+    });
+
+    fetch.resetMocks();
+
+    wrapper.find('form').simulate('submit');
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    expect(successURLGeneratorMock).toHaveBeenCalledWith(createdLocation1);
+    expect(
+      (wrapper.find('Router').props() as RouteComponentProps).history.location.pathname
+    ).toEqual(someMockURL);
+    wrapper.unmount();
+  });
+
+  it('cancel handler is called on cancel', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    fetch.mockResponse(JSON.stringify([]));
+    const cancelMock = jest.fn();
+
+    const wrapper = mount(
+      <Router history={history}>
+        <LocationForm onCancel={cancelMock} />
+      </Router>,
+      { attachTo: container }
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    wrapper.find('button#location-form-cancel-button').simulate('click');
+    wrapper.update();
+
+    expect(cancelMock).toHaveBeenCalled();
     wrapper.unmount();
   });
 

--- a/packages/location-management/src/components/NewLocationUnit/index.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/index.tsx
@@ -12,13 +12,15 @@ import { ADD_LOCATION_UNIT } from '../../lang';
 
 /** full props for the new location component */
 export interface NewLocationUnitProps
-  extends Pick<LocationFormProps, 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'>,
+  extends Pick<
+      LocationFormProps,
+      'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback' | 'successURLGenerator'
+    >,
     RouteComponentProps {
   openSRPBaseURL: string;
   instance: FormInstances;
   processInitialValues?: (formFields: LocationFormFields) => LocationFormFields;
-  successURL: string;
-  cancelURL: string;
+  cancelURLGenerator: () => string;
 }
 
 const defaultNewLocationUnitProps = {
@@ -28,8 +30,8 @@ const defaultNewLocationUnitProps = {
   hidden: [],
   disabled: [],
   service: OpenSRPService,
-  successURL: '',
-  cancelURL: '',
+  successURLGenerator: () => '',
+  cancelURLGenerator: () => '',
 };
 
 /** renders page where user can create new location unit
@@ -43,13 +45,16 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
     disabled,
     service,
     openSRPBaseURL,
-    successURL,
-    cancelURL,
+    successURLGenerator,
+    cancelURLGenerator,
     processInitialValues,
     disabledTreeNodesCallback,
   } = props;
   const history = useHistory();
-  const cancelHandler = () => history.push(cancelURL);
+  const cancelHandler = () => {
+    const cancelURL = cancelURLGenerator();
+    history.push(cancelURL);
+  };
   const user = useSelector((state) => getUser(state));
 
   const firstInitialValues = getLocationFormFields(undefined, instance);
@@ -57,7 +62,7 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
 
   const locationFormProps = {
     initialValues,
-    redirectAfterAction: successURL,
+    successURLGenerator,
     hidden,
     disabled,
     onCancel: cancelHandler,

--- a/packages/location-management/src/components/NewLocationUnit/index.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/index.tsx
@@ -12,14 +12,13 @@ import { ADD_LOCATION_UNIT } from '../../lang';
 
 /** full props for the new location component */
 export interface NewLocationUnitProps
-  extends Pick<
-      LocationFormProps,
-      'redirectAfterAction' | 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'
-    >,
+  extends Pick<LocationFormProps, 'hidden' | 'disabled' | 'service' | 'disabledTreeNodesCallback'>,
     RouteComponentProps {
   openSRPBaseURL: string;
   instance: FormInstances;
   processInitialValues?: (formFields: LocationFormFields) => LocationFormFields;
+  successURL: string;
+  cancelURL: string;
 }
 
 const defaultNewLocationUnitProps = {
@@ -29,6 +28,8 @@ const defaultNewLocationUnitProps = {
   hidden: [],
   disabled: [],
   service: OpenSRPService,
+  successURL: '',
+  cancelURL: '',
 };
 
 /** renders page where user can create new location unit
@@ -42,12 +43,13 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
     disabled,
     service,
     openSRPBaseURL,
-    redirectAfterAction,
+    successURL,
+    cancelURL,
     processInitialValues,
     disabledTreeNodesCallback,
   } = props;
   const history = useHistory();
-  const cancelHandler = () => history.push(redirectAfterAction);
+  const cancelHandler = () => history.push(cancelURL);
   const user = useSelector((state) => getUser(state));
 
   const firstInitialValues = getLocationFormFields(undefined, instance);
@@ -55,7 +57,7 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
 
   const locationFormProps = {
     initialValues,
-    redirectAfterAction,
+    redirectAfterAction: successURL,
     hidden,
     disabled,
     onCancel: cancelHandler,

--- a/packages/location-management/src/components/NewLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/tests/index.test.tsx
@@ -3,7 +3,7 @@ import { NewLocationUnit } from '..';
 import React from 'react';
 import { store } from '@opensrp/store';
 import { createBrowserHistory } from 'history';
-import { Router } from 'react-router';
+import { RouteComponentProps, Router } from 'react-router';
 import { Provider } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import { removeLocationUnits } from '../../../ducks/location-units';
@@ -92,5 +92,41 @@ describe('NewLocationUnit', () => {
     expect(wrapper.find('h5').text()).toMatchInlineSnapshot(`"Add Location Unit"`);
 
     expect(wrapper.find('LocationForm').text()).toMatchSnapshot('form rendered');
+  });
+
+  it('cancel url is used if passed', async () => {
+    fetch.mockResponse(JSON.stringify([]));
+    const cancelURL = '/canceledURL';
+
+    const props = {
+      ...locationProps,
+      match: {
+        ...locationProps.match,
+        params: { id: location1.id },
+      },
+      cancelURL,
+    };
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <NewLocationUnit {...props} />
+        </Router>
+      </Provider>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    // simulate click on cancel button
+    wrapper.find('button#location-form-cancel-button').simulate('click');
+    wrapper.update();
+
+    // check url
+    expect(
+      (wrapper.find('Router').props() as RouteComponentProps).history.location.pathname
+    ).toEqual(cancelURL);
   });
 });

--- a/packages/location-management/src/components/NewLocationUnit/tests/index.test.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/tests/index.test.tsx
@@ -104,7 +104,7 @@ describe('NewLocationUnit', () => {
         ...locationProps.match,
         params: { id: location1.id },
       },
-      cancelURL,
+      cancelURLGenerator: () => cancelURL,
     };
 
     const wrapper = mount(


### PR DESCRIPTION
- correct the redirection urls invoked when either after a successful form submission, or a cancel for creating new service points, and editing service points.
- Disable editing parentId when editing service points 

addresses #310 