### PR TITLE
Add search filter functionality to teamsLocation assign select

### DIFF
--- a/packages/opensrp-plans/src/components/AssignmentModal/index.tsx
+++ b/packages/opensrp-plans/src/components/AssignmentModal/index.tsx
@@ -106,6 +106,8 @@ function EditAssignmentsModal(props: EditAssignmentsModalProps) {
           defaultValue={defaultValue}
           onChange={handleChange as SelectProps<Dictionary[], string[]>['onChange']}
           options={options}
+          showSearch={true}
+          filterOption={optionFilter as SelectProps<Dictionary[], string[]>['filterOption']}
         />
       </Modal>
     </>
@@ -115,3 +117,12 @@ function EditAssignmentsModal(props: EditAssignmentsModalProps) {
 EditAssignmentsModal.defaultProps = defaultProps;
 
 export { EditAssignmentsModal };
+
+/** filters what options to show depending on the string input
+ *
+ * @param input - the string input
+ * @param option - a single option
+ */
+export const optionFilter = (input: string, option: SelectOption) => {
+  return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0;
+};

--- a/packages/opensrp-plans/src/components/AssignmentModal/index.tsx
+++ b/packages/opensrp-plans/src/components/AssignmentModal/index.tsx
@@ -124,5 +124,5 @@ export { EditAssignmentsModal };
  * @param option - a single option
  */
 export const optionFilter = (input: string, option: SelectOption) => {
-  return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0;
+  return option.label.toLowerCase().includes(input.toLowerCase());
 };

--- a/packages/opensrp-plans/src/components/AssignmentModal/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/components/AssignmentModal/tests/index.test.tsx
@@ -49,6 +49,24 @@ describe('planAssignment modal', () => {
       wrapper.update();
     });
 
+    // show search is true
+    expect((wrapper.find('Modal Select').props() as Dictionary).showSearch).toBeTruthy();
+
+    // filter props works correctly
+    expect(
+      (wrapper.find('Modal Select').props() as Dictionary).filterOption('lue2', {
+        label: 'label2',
+        value: 'value2',
+      })
+    ).toBeTruthy();
+
+    expect(
+      (wrapper.find('Modal Select').props() as Dictionary).filterOption('lube2', {
+        label: 'label2',
+        value: 'value2',
+      })
+    ).toBeFalsy();
+
     // try saving
     const saveButton = wrapper.find('button').at(3);
     expect(saveButton.text()).toEqual(SAVE);

--- a/packages/opensrp-plans/src/components/AssignmentModal/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/components/AssignmentModal/tests/index.test.tsx
@@ -54,7 +54,7 @@ describe('planAssignment modal', () => {
 
     // filter props works correctly
     expect(
-      (wrapper.find('Modal Select').props() as Dictionary).filterOption('lue2', {
+      (wrapper.find('Modal Select').props() as Dictionary).filterOption('abel2', {
         label: 'label2',
         value: 'value2',
       })


### PR DESCRIPTION
Add search filter functionality to select component used for teams and locations assignment in missions

close #481