### PR TITLE
Resolve bug image preview not displaying when editing product

### DIFF
--- a/packages/product-catalogue/package.json
+++ b/packages/product-catalogue/package.json
@@ -37,7 +37,7 @@
     "@onaio/redux-reducer-registry": "^0.0.9",
     "@onaio/utils": "^0.0.1",
     "@opensrp/notifications": "^0.0.1",
-    "@opensrp/react-utils": "^0.0.1",
+    "@opensrp/react-utils": "^0.0.2",
     "@opensrp/reducer-factory": "^0.0.11",
     "@opensrp/server-service": "^0.0.13",
     "@opensrp/pkg-config": "^0.0.1",

--- a/packages/product-catalogue/src/components/ProductForm/index.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/index.tsx
@@ -187,15 +187,24 @@ const ProductForm = (props: ProductFormProps) => {
   };
 
   React.useEffect(() => {
+    let objectURL: string | null = null;
+
     if (isEditMode && initialValues.photoURL) {
       fetchProtectedImage((initialValues.photoURL as string).replace('http', 'https'))
         .then((url: string | null) => {
           if (url) {
+            objectURL = url;
             setImageUrl(url);
           }
         })
         .catch((_: HTTPError) => sendErrorNotification(ERROR_IMAGE_LOAD));
     }
+    return () => {
+      if (objectURL) {
+        // For optimal performance and memeory usage, release object URL on unmount
+        URL.revokeObjectURL(objectURL);
+      }
+    };
   }, [isEditMode, baseURL, initialValues.photoURL]);
 
   /** if plan is updated or saved redirect to plans page */

--- a/packages/product-catalogue/src/components/ProductForm/index.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/index.tsx
@@ -20,6 +20,7 @@ import {
   CONDITION_PLACEHOLDER,
   DESCRIBE_THE_PRODUCTS_USE,
   ENTER_PRODUCTS_NAME,
+  ERROR_IMAGE_LOAD,
   MATERIAL_NUMBER,
   MATERIAL_NUMBER_PLACEHOLDER,
   NO,
@@ -32,6 +33,8 @@ import {
   USED_APPROPRIATELY,
   YES,
 } from '../../lang';
+import { HTTPError } from '@opensrp/server-service';
+import { fetchProtectedImage } from '@opensrp/react-utils';
 
 /** type describing the fields in the product catalogue form */
 export interface ProductFormFields {
@@ -129,8 +132,7 @@ const tailLayout = {
 const ProductForm = (props: ProductFormProps) => {
   const { initialValues, redirectAfterAction, baseURL } = props;
   const isEditMode = !!initialValues.uniqueId;
-  const defaultImageUrl = isEditMode ? props.initialValues.photoURL : '';
-  const [imageUrl, setImageUrl] = useState<string | ArrayBuffer>(defaultImageUrl as string);
+  const [imageUrl, setImageUrl] = useState<string | ArrayBuffer>('');
   const [areWeDoneHere, setAreWeDoneHere] = useState<boolean>(false);
   const history = useHistory();
 
@@ -183,6 +185,18 @@ const ProductForm = (props: ProductFormProps) => {
     readURL(file);
     setFieldValue('photoURL', file.originFileObj);
   };
+
+  React.useEffect(() => {
+    if (isEditMode) {
+      fetchProtectedImage((initialValues.photoURL as string).replace('http', 'https'))
+        .then((url: string | null) => {
+          if (url) {
+            setImageUrl(url);
+          }
+        })
+        .catch((_: HTTPError) => sendErrorNotification(ERROR_IMAGE_LOAD));
+    }
+  }, [isEditMode, baseURL, initialValues.photoURL]);
 
   /** if plan is updated or saved redirect to plans page */
   if (areWeDoneHere) {

--- a/packages/product-catalogue/src/components/ProductForm/index.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/index.tsx
@@ -187,7 +187,7 @@ const ProductForm = (props: ProductFormProps) => {
   };
 
   React.useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode && initialValues.photoURL) {
       fetchProtectedImage((initialValues.photoURL as string).replace('http', 'https'))
         .then((url: string | null) => {
           if (url) {

--- a/packages/product-catalogue/src/components/ProductForm/tests/fixtures.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/tests/fixtures.tsx
@@ -7,5 +7,18 @@ export const product2 = {
   condition: 'this shoudl be optional',
   appropriateUsage: 'this should be optional',
   accountabilityPeriod: 2,
+  photoURL: '',
+};
+
+export const product3 = {
+  uniqueId: 4,
+  productName: 'Change name Test',
+  isAttractiveItem: false,
+  materialNumber: 'asd',
+  availability: 'yeah',
+  condition: 'this should be optional',
+  appropriateUsage: 'this should be optional',
+  accountabilityPeriod: 2,
   photoURL: 'http://mg-eusm-staging.smartregister.org/opensrp/multimedia/media/4',
+  serverVersion: 29,
 };

--- a/packages/product-catalogue/src/components/ProductForm/tests/index.test.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/tests/index.test.tsx
@@ -24,6 +24,8 @@ jest.mock('@opensrp/react-utils', () => ({
 const fetch = require('jest-fetch-mock');
 
 describe('productForm', () => {
+  global.URL.revokeObjectURL = jest.fn();
+
   afterEach(() => {
     fetch.resetMocks();
     jest.clearAllMocks();
@@ -582,8 +584,8 @@ describe('productForm', () => {
       'https://mg-eusm-staging.smartregister.org/opensrp/multimedia/media/4'
     );
     expect(wrapper.find('img').get(0).props.src).toEqual('hello');
-
     wrapper.unmount();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('hello');
   });
 
   it('does not display image if fetch image fails', async () => {

--- a/packages/product-catalogue/src/components/ProductForm/tests/index.test.tsx
+++ b/packages/product-catalogue/src/components/ProductForm/tests/index.test.tsx
@@ -8,11 +8,17 @@ import toJson from 'enzyme-to-json';
 import { product1 } from '../../../ducks/productCatalogue/tests/fixtures';
 import { sendErrorNotification } from '@opensrp/notifications';
 import { CATALOGUE_LIST_VIEW_URL } from '../../../constants';
-import { product2 } from './fixtures';
+import { product2, product3 } from './fixtures';
+import * as opensrpReactUtils from '@opensrp/react-utils';
 
 jest.mock('@opensrp/notifications', () => {
   return { sendSuccessNotification: jest.fn(), sendErrorNotification: jest.fn() };
 });
+
+jest.mock('@opensrp/react-utils', () => ({
+  __esModule: true,
+  ...Object.assign({}, jest.requireActual('@opensrp/react-utils')),
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetch = require('jest-fetch-mock');
@@ -20,6 +26,8 @@ const fetch = require('jest-fetch-mock');
 describe('productForm', () => {
   afterEach(() => {
     fetch.resetMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('renders without crashing', async () => {
@@ -548,5 +556,90 @@ describe('productForm', () => {
 
     expect(errorNotificationSMock).toHaveBeenCalledWith('Error', otherErrorMessage);
     (sendErrorNotification as jest.Mock).mockReset();
+  });
+
+  it('fetches image if photoURL is given', async () => {
+    const fetchProtectedImageMock = jest
+      .spyOn(opensrpReactUtils, 'fetchProtectedImage')
+      .mockImplementation(() => Promise.resolve('hello'));
+
+    const props = {
+      initialValues: product3,
+    };
+
+    const wrapper = mount(
+      <MemoryRouter>
+        <ProductForm {...props} />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    wrapper.update();
+
+    expect(fetchProtectedImageMock).toHaveBeenCalledWith(
+      'https://mg-eusm-staging.smartregister.org/opensrp/multimedia/media/4'
+    );
+    expect(wrapper.find('img').get(0).props.src).toEqual('hello');
+
+    wrapper.unmount();
+  });
+
+  it('does not display image if fetch image fails', async () => {
+    const fetchProtectedImageMock = jest
+      .spyOn(opensrpReactUtils, 'fetchProtectedImage')
+      .mockImplementation(() => Promise.resolve(null));
+
+    const props = {
+      initialValues: product3,
+    };
+
+    const wrapper = mount(
+      <MemoryRouter>
+        <ProductForm {...props} />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    wrapper.update();
+
+    expect(fetchProtectedImageMock).toHaveBeenCalledWith(
+      'https://mg-eusm-staging.smartregister.org/opensrp/multimedia/media/4'
+    );
+    expect(toJson(wrapper.find('img'))).toBeFalsy();
+
+    wrapper.unmount();
+  });
+
+  it('display error toast if fetching image fails', async () => {
+    const fetchProtectedImageMock = jest
+      .spyOn(opensrpReactUtils, 'fetchProtectedImage')
+      .mockImplementation(() => Promise.reject('error'));
+
+    const props = {
+      initialValues: product3,
+    };
+
+    const wrapper = mount(
+      <MemoryRouter>
+        <ProductForm {...props} />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    wrapper.update();
+
+    expect(fetchProtectedImageMock).toHaveBeenCalledWith(
+      'https://mg-eusm-staging.smartregister.org/opensrp/multimedia/media/4'
+    );
+    expect(toJson(wrapper.find('img'))).toBeFalsy();
+    expect(sendErrorNotification).toHaveBeenCalledWith('Image could not be loaded');
+
+    wrapper.unmount();
   });
 });

--- a/packages/product-catalogue/src/lang.ts
+++ b/packages/product-catalogue/src/lang.ts
@@ -40,3 +40,6 @@ export const AVAILABILITY_LABEL = i18n.t('Is it there?');
 export const ATTRACTIVE_ITEM_LABEL = i18n.t('Attractive item?');
 export const MATERIAL_NUMBER_PLACEHOLDER = "Enter the product's material number";
 export const SUBMIT = i18n.t('Submit');
+
+// Errors
+export const ERROR_IMAGE_LOAD = 'Image could not be loaded';

--- a/packages/product-catalogue/src/lang.ts
+++ b/packages/product-catalogue/src/lang.ts
@@ -42,4 +42,4 @@ export const MATERIAL_NUMBER_PLACEHOLDER = "Enter the product's material number"
 export const SUBMIT = i18n.t('Submit');
 
 // Errors
-export const ERROR_IMAGE_LOAD = 'Image could not be loaded';
+export const ERROR_IMAGE_LOAD = i18n.t('Image could not be loaded');

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -53,7 +53,6 @@ export const handleSessionOrTokenExpiry = async () => {
  */
 export const fetchProtectedImage = async (imageURL: string) => {
   const token = await handleSessionOrTokenExpiry();
-
   const response = await customFetch(imageURL, {
     headers: {
       authorization: `Bearer ${token}`,
@@ -62,7 +61,8 @@ export const fetchProtectedImage = async (imageURL: string) => {
   });
 
   if (response) {
-    return URL.createObjectURL(await response.blob());
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
   }
 
   return null;

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -47,7 +47,8 @@ export const handleSessionOrTokenExpiry = async () => {
 };
 
 /**
- * Fetch an image that requires authentication
+ * Fetch an image that requires authentication and returns an
+ * object URL from URL.createObjectURL
  *
  * @param imageURL the image source url
  */

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -3,6 +3,7 @@ import {
   getFetchOptions,
   OpenSRPService as GenericOpenSRPService,
   OPENSRP_API_BASE_URL,
+  customFetch,
 } from '@opensrp/server-service';
 import { history } from '@onaio/connected-reducer-registry';
 import { refreshToken } from '@onaio/gatekeeper';
@@ -43,4 +44,26 @@ export const handleSessionOrTokenExpiry = async () => {
   } else {
     return getAccessToken(store.getState());
   }
+};
+
+/**
+ * Fetch an image that requires authentication
+ *
+ * @param imageURL the image source url
+ */
+export const fetchProtectedImage = async (imageURL: string) => {
+  const token = await handleSessionOrTokenExpiry();
+
+  const response = await customFetch(imageURL, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+    method: 'GET',
+  });
+
+  if (response) {
+    return URL.createObjectURL(await response.blob());
+  }
+
+  return null;
 };

--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { fetchProtectedImage, handleSessionOrTokenExpiry, OpenSRPService } from '../dataLoaders';
 import fetch from 'jest-fetch-mock';
 import MockDate from 'mockdate';

--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -89,11 +89,6 @@ describe('helpers/dataLoaders/fetchProtectedImage', () => {
     );
 
     await flushPromises();
-    /***
-     * @todo Most appropriate test case would be to assert
-     * expect((global as any).URL.createObjectURL).toHaveBeenCalledWith(blob);
-     * but mocking a blob response was a challenge
-     */
     expect(objectURL).toEqual(null);
   });
 });

--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -74,9 +74,10 @@ describe('helpers/dataLoaders/fetchProtectedImage', () => {
       },
     ]);
     /***
-     * @todo Most appropriate test case would be to assert
+     * @todo Most appropriate test case would be to also assert
      * expect((global as any).URL.createObjectURL).toHaveBeenCalledWith(blob);
-     * but mocking a blob response was a challenge
+     * but mocking a blob response was a challenge. Hence URL.createOjectURL was mocked
+     * above as (global as any).URL.createObjectURL = jest.fn().mockReturnValue('hello');
      */
     expect(objectURL).toEqual('hello');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,14 +2727,6 @@
   resolved "https://registry.yarnpkg.com/@opensrp/notifications/-/notifications-0.0.1.tgz#73d9fd283be241b15754607d8677b29761d587d3"
   integrity sha512-qqvx4lcAy4iMUSnPk5riS6m7Se8GwGpSMS9M/iBoP3bT/TInhu5Ixm2DsM2s6OC9FSt8CE7p6T6cA0x711xk4w==
 
-"@opensrp/react-utils@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@opensrp/react-utils/-/react-utils-0.0.1.tgz#25d0dfab92245c730141529fa389ea2833215ed2"
-  integrity sha512-vZVjYnW1MkU5pMpaIE8F73uuD2uHldS8c20sCRAhyHZcb+InljpZ/CiPD4JViAXx88Szru8BDuw54x//OzBPWg==
-  dependencies:
-    "@opensrp/notifications" "^0.0.2"
-    antd "^4.6.3"
-
 "@opensrp/reducer-factory@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@opensrp/reducer-factory/-/reducer-factory-0.0.1.tgz#4a544e6ec29d97a7d8ba2d07f3a63a21ec49e723"


### PR DESCRIPTION
Addresses #399 

The endpoint to get the image required authentication. A 302 status code was being returned with a redirection to the login page. This was resolved by adding the token to the request headers when getting the image

![Screenshot from 2021-02-22 11-21-05](https://user-images.githubusercontent.com/19818819/108681405-2a983500-7500-11eb-9fa8-7078702e7668.png)
