### PR TITLE
Move @reduxjs/toolkit from peer dependencies to dependencies

### DIFF
--- a/packages/pkg-config/package.json
+++ b/packages/pkg-config/package.json
@@ -32,10 +32,8 @@
   "bugs": {
     "url": "https://github.com/opensrp/web/issues"
   },
-  "peerDependencies": {
-    "@reduxjs/toolkit": "^1.5.0"
-  },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.5.0",
     "i18next": "^19.8.4",
     "react-i18next": "^11.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,6 +6424,11 @@ date-fns@^2.15.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
+date-fns@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
After publishing `@opensrp/form-config`, the new version was requesting the package to be added in reveal.
This change moves package `@opensrp/form-config`  in `pkg-config` to `dependencies`