### PR TITLE
Active plan only with areas

### DIFF
--- a/packages/opensrp-plans/src/components/ActivateMission/index.tsx
+++ b/packages/opensrp-plans/src/components/ActivateMission/index.tsx
@@ -1,9 +1,10 @@
 import { PlanDefinition, PlanStatus } from '@opensrp/plan-form-core';
 import { OpenSRPService } from '../../helpers/dataLoaders';
 import React from 'react';
-import { Card, Button, Typography } from 'antd';
+import { Card, Button, Typography, Tooltip } from 'antd';
 import {
   ACTIVATE_MISSION,
+  CANNOT_ACTIVATE_PLAN_WITH_NO_JURISDICTIONS,
   FAILED_TO_ACTIVATE_MISSION,
   SUCCESSFULLY_ACTIVATED_MISSION,
 } from '../../lang';
@@ -40,6 +41,8 @@ const ActivateMissionCard = (props: ActivateMissionProps) => {
   if (!plan || !planIsDraft) {
     return null;
   }
+  const planHasJurisdictions = plan.jurisdiction.length > 0;
+  const isActivateButtonDisabled = !planHasJurisdictions;
 
   /** post the plan with a new status of active */
   const clickHandler = () => {
@@ -57,15 +60,23 @@ const ActivateMissionCard = (props: ActivateMissionProps) => {
       });
   };
 
+  const ActivateButton = (
+    <Button onClick={clickHandler} type="primary" disabled={isActivateButtonDisabled}>
+      {ACTIVATE_MISSION}
+    </Button>
+  );
+
   return (
     <Card
       className="activate-plan"
       bordered={false}
       title={<Title level={5}>{ACTIVATE_MISSION}</Title>}
     >
-      <Button onClick={clickHandler} type="primary">
-        {ACTIVATE_MISSION}
-      </Button>
+      {planHasJurisdictions ? (
+        ActivateButton
+      ) : (
+        <Tooltip title={CANNOT_ACTIVATE_PLAN_WITH_NO_JURISDICTIONS}>{ActivateButton}</Tooltip>
+      )}
     </Card>
   );
 };

--- a/packages/opensrp-plans/src/components/ActivateMission/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/components/ActivateMission/tests/index.test.tsx
@@ -4,11 +4,7 @@ import { ActivateMissionCard } from '..';
 import toJson from 'enzyme-to-json';
 import { eusmPlans } from '../../../ducks/planDefinitions/tests/fixtures';
 import { PlanDefinition, PlanStatus } from '@opensrp/plan-form-core';
-import {
-  FAILED_TO_ACTIVATE_MISSION,
-  ONLY_DRAFT_MISSIONS_CAN_BE_ACTIVATED,
-  SUCCESSFULLY_ACTIVATED_MISSION,
-} from '../../../lang';
+import { FAILED_TO_ACTIVATE_MISSION, SUCCESSFULLY_ACTIVATED_MISSION } from '../../../lang';
 import { act } from 'react-dom/test-utils';
 import * as notifications from '@opensrp/notifications';
 
@@ -44,6 +40,31 @@ describe('activate mission', () => {
   });
 
   it('works correctly for draft plans', async () => {
+    // plan is active
+    const mockCallback = jest.fn();
+
+    const mission = {
+      ...plan,
+      jurisdiction: [],
+      status: PlanStatus.DRAFT,
+    };
+    const props = {
+      plan: mission as PlanDefinition,
+      submitCallback: mockCallback,
+    };
+    const wrapper = mount(<ActivateMissionCard {...props} />);
+
+    // renders the activate button
+    expect(wrapper.find('button')).toHaveLength(1);
+
+    // check button is disabled
+    expect(wrapper.find('button').props().disabled).toEqual(true);
+
+    // expect toolkit too.
+    expect(wrapper.find('Tooltip')).toHaveLength(1);
+  });
+
+  it('disabled when plan has no Jurisdictions', async () => {
     fetch.once(JSON.stringify({}));
     // plan is active
     const mockCallback = jest.fn();
@@ -57,7 +78,6 @@ describe('activate mission', () => {
       submitCallback: mockCallback,
     };
     const wrapper = mount(<ActivateMissionCard {...props} />);
-    expect(wrapper.text().includes(ONLY_DRAFT_MISSIONS_CAN_BE_ACTIVATED)).toBeFalsy();
     // renders the activate button
     expect(wrapper.find('button')).toHaveLength(1);
 

--- a/packages/opensrp-plans/src/lang.ts
+++ b/packages/opensrp-plans/src/lang.ts
@@ -38,3 +38,6 @@ export const SERVICE_POINTS_VISITED = i18n.t('Service points visited');
 export const PRODUCTS_CHECKED = i18n.t('Products checked');
 export const NUMBER_OF_FLAGGED_PRODUCTS = i18n.t('Number of flagged products');
 export const FETCHING_MISSION_INDICATORS_DATA = i18n.t('Fetching mission indicators data');
+export const CANNOT_ACTIVATE_PLAN_WITH_NO_JURISDICTIONS = i18n.t(
+  'Assign jurisdictions to the Plan, to enable activating it'
+);

--- a/packages/plan-form/src/Form/componentsUtils/tests/status.test.tsx
+++ b/packages/plan-form/src/Form/componentsUtils/tests/status.test.tsx
@@ -117,4 +117,30 @@ describe('status Renderer', () => {
     // nothing should change
     expect(setFieldMock).toHaveBeenCalledWith({ status: 'retired' });
   });
+  it('shows popup when trying to click activate but assigned Jurisdictions is null', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const setFieldMock = jest.fn();
+    const props = {
+      disabledFields: [],
+      disAllowedStatusChoices: [],
+      setFieldsValue: setFieldMock,
+      assignedJurisdictions: [],
+    };
+    const wrapper = mount(<PlanStatusRenderer {...props} />, { attachTo: container });
+
+    // attempt simulating confirm on active radio button
+    wrapper.find('input[value="active"]').simulate('click');
+    // look for popup with info that require activating plan
+    expect(wrapper.find('.ant-popover-content').text()).toMatchInlineSnapshot(
+      `"Assign jurisdictions to the Plan, to enable activating itCancelOK"`
+    );
+
+    // simulate click on both accept deny button
+    wrapper.find('button').first().simulate('click');
+    wrapper.find('button').last().simulate('click');
+
+    // nothing should change
+    expect(setFieldMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/plan-form/src/Form/index.tsx
+++ b/packages/plan-form/src/Form/index.tsx
@@ -78,6 +78,7 @@ import {
   goalDescription,
   status,
   title,
+  jurisdictions,
 } from '@opensrp/plan-form-core';
 import moment, { Moment } from 'moment';
 import { Select, Input, DatePicker } from 'antd';
@@ -419,6 +420,7 @@ const PlanForm = (props: PlanFormProps) => {
               setFieldsValue={form.setFieldsValue}
               disabledFields={disabledFields}
               disAllowedStatusChoices={disAllowedStatusChoices}
+              assignedJurisdictions={form.getFieldsValue()[jurisdictions]}
             />
           </FormItem>
           <FormItem

--- a/packages/plan-form/src/lang.ts
+++ b/packages/plan-form/src/lang.ts
@@ -180,3 +180,7 @@ export const SETTING_STATUS_TO_COMPLETE = i18n.t(
 export const SETTING_STATUS_TO_RETIRED = i18n.t(
   "Are you sure, you won't be able to change the status for retired plans"
 );
+export const OK = i18n.t('OK');
+export const CANNOT_ACTIVATE_PLAN_WITH_NO_JURISDICTIONS = i18n.t(
+  'Assign jurisdictions to the Plan, to enable activating it'
+);


### PR DESCRIPTION
close #485 
- problem : possible to activate mission that have no assigned locations
Added constraint in 2 places:
 - plan-form
 - mission assignments: activate mission