### PR TITLE
Specify geojson type field value when creating service points

### DIFF
--- a/packages/inventory/src/constants.ts
+++ b/packages/inventory/src/constants.ts
@@ -38,6 +38,7 @@ export const tablePaginationOptions = {
   defaultPageSize: TABLE_PAGE_SIZE,
   pageSizeOptions: TABLE_PAGE_SIZE_OPTIONS,
 };
+export const GEOJSON_TYPE_STRING = 'Feature';
 
 //endpoints
 export const GET_INVENTORY_BY_SERVICE_POINT = 'stockresource/servicePointId/';

--- a/packages/inventory/src/containers/CreateServicePoint/index.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/index.tsx
@@ -3,6 +3,7 @@ import { FormInstances, LocationUnit, NewLocationUnit } from '@opensrp/location-
 import { RouteComponentProps } from 'react-router';
 import { CommonProps, defaultCommonProps } from '../../helpers/common';
 import {
+  GEOJSON_TYPE_STRING,
   INVENTORY_SERVICE_POINT_LIST_VIEW,
   INVENTORY_SERVICE_POINT_PROFILE_VIEW,
 } from '../../constants';
@@ -30,7 +31,11 @@ const ServicePointsAdd = (props: ServicePointAddTypes) => {
       `${INVENTORY_SERVICE_POINT_PROFILE_VIEW}/${payload?.id}`, // todo if payload is missing
     cancelURLGenerator: () => INVENTORY_SERVICE_POINT_LIST_VIEW,
     disabled: ['isJurisdiction'],
-    processInitialValues: (data: LocationFormFields) => ({ ...data, isJurisdiction: false }),
+    processInitialValues: (data: LocationFormFields) => ({
+      ...data,
+      isJurisdiction: false,
+      type: GEOJSON_TYPE_STRING,
+    }),
     disabledTreeNodesCallback,
   };
 

--- a/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
+++ b/packages/inventory/src/containers/CreateServicePoint/tests/index.test.tsx
@@ -68,6 +68,7 @@ describe('CreateServicePoint', () => {
 
     expect(locationFormProps.hidden).toEqual(commonHiddenFields);
     expect(initialValues.instance).toEqual('eusm');
+    expect(initialValues.type).toEqual('Feature');
     expect(locationFormProps.disabled).toEqual(['isJurisdiction']);
 
     // test re-direction url on chancel


### PR DESCRIPTION
before:
- the type field is hidden, and has a default value of undefined, when creating the service point fields, undefined value are removed from the payload.
Fix:
- explicitely provide the default value of the `type` field when creating Service points, this way it will not be undefined, when creating the payload,

addresses https://github.com/OpenSRP/opensrp-client-eusm/issues/60