### PR TITLE
plan title style fix

### DIFF
--- a/packages/opensrp-plans/src/components/PlanInfo/index.tsx
+++ b/packages/opensrp-plans/src/components/PlanInfo/index.tsx
@@ -71,7 +71,7 @@ const PlanInfo = (props: PlanInfoProps) => {
           </span>
           <div className="plan-detail-section">
             <div>
-              <h4>{plan.title}</h4>
+              <span className="ant-page-header-heading-title">{plan.title}</span>
             </div>
             <div className="plan-description">
               <Link to={`${PLANS_EDIT_VIEW_URL}/${planId}`}>{EDIT}</Link>


### PR DESCRIPTION
This PR addresses #515 

<img width="1440" alt="Screenshot 2021-03-01 at 2 23 44 PM" src="https://user-images.githubusercontent.com/68631902/109477657-1cb35880-7a9a-11eb-9277-17602657f4b4.png">
