### PR TITLE
Correct order of mocked responses

### DIFF
--- a/packages/keycloak-user-management/src/components/CreateEditUser/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUser/tests/index.test.tsx
@@ -167,11 +167,16 @@ describe('components/CreateEditUser', () => {
   });
 
   it('renders correctly with user id', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userGroup));
-    fetch.mockResponseOnce(JSON.stringify(userGroup[1]));
-    fetch.mockResponseOnce(JSON.stringify(keycloakUser));
-    fetch.mockResponseOnce(JSON.stringify(requiredActions));
-    fetch.mockResponseOnce(JSON.stringify(practitioner1));
+    fetch
+      .once(JSON.stringify(userGroup))
+      .once(JSON.stringify(userGroup[1]))
+      .once(JSON.stringify(userGroup[1]))
+      .once(JSON.stringify(practitioner1))
+      .once(JSON.stringify(practitioner1))
+      .once(JSON.stringify(requiredActions))
+      .once(JSON.stringify(userGroup[1]))
+      .once(JSON.stringify(requiredActions))
+      .once(JSON.stringify(userGroup[1]));
 
     const wrapper = mount(
       <Provider store={store}>
@@ -189,6 +194,20 @@ describe('components/CreateEditUser', () => {
     const row = wrapper.find('Row').at(0);
 
     expect(row.props()).toMatchSnapshot();
+
+    const fetchMockCalls = fetch.mock.calls.map((call) => call[0]);
+    expect(fetchMockCalls).toEqual([
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/groups',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/cab07278-c77b-4bc7-b154-bcbf01b7d35b/groups',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/cab07278-c77b-4bc7-b154-bcbf01b7d35b/groups',
+      'https://opensrp-stage.smartregister.org/opensrp/rest/practitioner/user/cab07278-c77b-4bc7-b154-bcbf01b7d35b',
+      'https://opensrp-stage.smartregister.org/opensrp/rest/practitioner/user/cab07278-c77b-4bc7-b154-bcbf01b7d35b',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/authentication/required-actions/',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/cab07278-c77b-4bc7-b154-bcbf01b7d35b/groups',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/authentication/required-actions/',
+      'https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/cab07278-c77b-4bc7-b154-bcbf01b7d35b/groups',
+    ]);
+
     wrapper.unmount();
   });
 


### PR DESCRIPTION
failure reason:
- the order of mocked responses went out of sync, for some reason!.

- Corrected the order, added an assertion that would fail, if such a situation happened again.