### PR TITLE
531 fix logout redirecting to unauthorized page

### DIFF
--- a/app/src/App/App.tsx
+++ b/app/src/App/App.tsx
@@ -625,7 +625,7 @@ const App: React.FC = () => {
             />
             <PublicComponent exact path={APP_CALLBACK_PATH} component={CallbackComponent} />
             {/* tslint:enable jsx-no-lambda */}
-            <PublicComponent
+            <ConnectedPrivateRoute
               redirectPath={APP_CALLBACK_URL}
               disableLoginProtection={DISABLE_LOGIN_PROTECTION}
               exact

--- a/app/src/App/App.tsx
+++ b/app/src/App/App.tsx
@@ -625,7 +625,7 @@ const App: React.FC = () => {
             />
             <PublicComponent exact path={APP_CALLBACK_PATH} component={CallbackComponent} />
             {/* tslint:enable jsx-no-lambda */}
-            <PrivateComponent
+            <PublicComponent
               redirectPath={APP_CALLBACK_URL}
               disableLoginProtection={DISABLE_LOGIN_PROTECTION}
               exact

--- a/app/src/App/tests/App.test.tsx
+++ b/app/src/App/tests/App.test.tsx
@@ -10,6 +10,7 @@ import App, { CallbackComponent, LoadingComponent, SuccessfulLoginComponent } fr
 import { expressAPIResponse } from './fixtures';
 import { mount } from 'enzyme';
 import { authenticateUser } from '@onaio/session-reducer';
+import * as serverLogout from '@opensrp/server-logout';
 
 jest.mock('../../configs/env');
 
@@ -178,5 +179,21 @@ describe('App - authenticated', () => {
       },
     });
     wrapper.unmount();
+  });
+
+  it('correctly logs out user', async () => {
+    const mock = jest.spyOn(serverLogout, 'logout');
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: `/logout` }]}>
+          <App />
+        </MemoryRouter>
+      </Provider>
+    );
+    await act(async () => {
+      await new Promise<unknown>((resolve) => setImmediate(resolve));
+      wrapper.update();
+    });
+    expect(mock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
addresses #531 

We don't need to have the logout component as a private component since private component enforces the use of roles which we really don't need when logging out a user.