### PR TITLE
Disallow forward slash in mission name

### DIFF
--- a/packages/plan-form/src/Form/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/plan-form/src/Form/tests/__snapshots__/index.test.tsx.snap
@@ -69,15 +69,7 @@ Array [
   },
   Object {
     "errors": Array [
-      "'title' is required",
-    ],
-    "name": Array [
-      "title",
-    ],
-  },
-  Object {
-    "errors": Array [
-      "'name' is required",
+      "Plan name cannot contain '/'",
     ],
     "name": Array [
       "name",

--- a/packages/plan-form/src/Form/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/plan-form/src/Form/tests/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ Array [
       "Plan name cannot contain '/'",
     ],
     "name": Array [
-      "name",
+      "title",
     ],
   },
   Object {

--- a/packages/plan-form/src/Form/tests/index.test.tsx
+++ b/packages/plan-form/src/Form/tests/index.test.tsx
@@ -232,6 +232,11 @@ describe('containers/forms/PlanForm', () => {
 
     // next we set wrong values for fields that expect specific values
 
+    // Set title for the plan with forward slash
+    wrapper
+      .find('#title input')
+      .simulate('change', { target: { name: 'title', value: 'Plan / Name' } });
+
     // Set wrong interventionType field value
     formInstance.setFieldsValue({
       interventionType: 'Oov',

--- a/packages/plan-form/src/helpers/utils.tsx
+++ b/packages/plan-form/src/helpers/utils.tsx
@@ -16,6 +16,7 @@ import moment, { Moment } from 'moment';
 import { PlanFormFields } from './types';
 import { Dictionary } from '@onaio/utils';
 import { cloneDeep } from 'lodash';
+import { PLAN_NAME_CANNOT_CONTAIN_SLASHES } from '../lang';
 
 export const validationRules = {
   activities: {
@@ -43,7 +44,17 @@ export const validationRules = {
     id: [{ type: 'string' }] as Rule[],
     name: [{ type: 'string' }] as Rule[],
   },
-  name: [{ type: 'string', required: true }] as Rule[],
+  name: [
+    { type: 'string', required: true },
+    () => ({
+      validator(_, value) {
+        if (value.includes('/')) {
+          return Promise.reject(PLAN_NAME_CANNOT_CONTAIN_SLASHES);
+        }
+        return Promise.resolve();
+      },
+    }),
+  ] as Rule[],
   taskGenerationStatus: [
     {
       type: 'enum',

--- a/packages/plan-form/src/helpers/utils.tsx
+++ b/packages/plan-form/src/helpers/utils.tsx
@@ -44,7 +44,15 @@ export const validationRules = {
     id: [{ type: 'string' }] as Rule[],
     name: [{ type: 'string' }] as Rule[],
   },
-  name: [
+  name: [{ type: 'string', required: true }] as Rule[],
+  taskGenerationStatus: [
+    {
+      type: 'enum',
+      enum: Object.values(taskGenerationStatuses),
+    },
+  ] as Rule[],
+  teamAssignmentStatus: [{ type: 'string' }] as Rule[],
+  title: [
     { type: 'string', required: true },
     () => ({
       validator(_, value) {
@@ -55,14 +63,6 @@ export const validationRules = {
       },
     }),
   ] as Rule[],
-  taskGenerationStatus: [
-    {
-      type: 'enum',
-      enum: Object.values(taskGenerationStatuses),
-    },
-  ] as Rule[],
-  teamAssignmentStatus: [{ type: 'string' }] as Rule[],
-  title: [{ type: 'string', required: true }] as Rule[],
   version: [{ type: 'string' }] as Rule[],
   status: [
     {

--- a/packages/plan-form/src/lang.ts
+++ b/packages/plan-form/src/lang.ts
@@ -184,3 +184,4 @@ export const OK = i18n.t('OK');
 export const CANNOT_ACTIVATE_PLAN_WITH_NO_JURISDICTIONS = i18n.t(
   'Assign jurisdictions to the Plan, to enable activating it'
 );
+export const PLAN_NAME_CANNOT_CONTAIN_SLASHES = i18n.t("Plan name cannot contain '/'");


### PR DESCRIPTION
close #533 
- Adds validation rule that disallows creating plan(mission) names that contain slashes