### PR TITLE
Reloading page redirects to unauthorised page

### DIFF
--- a/packages/react-utils/src/helpers/componentUtils.tsx
+++ b/packages/react-utils/src/helpers/componentUtils.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Route, RouteProps, RouteComponentProps } from 'react-router';
 import { useSelector } from 'react-redux';
-import { getExtraData } from '@onaio/session-reducer';
+import { getExtraData, isAuthenticated } from '@onaio/session-reducer';
 import { getAllConfigs } from '@opensrp/pkg-config';
 import ConnectedPrivateRoute from '@onaio/connected-private-route';
 import { UnauthorizedPage } from '../components/UnauthorizedPage';
@@ -35,13 +35,17 @@ export const PrivateComponent = (props: ComponentProps) => {
     opensrpBaseURL: configs.opensrpBaseURL,
   };
   const extraData = useSelector((state) => getExtraData(state));
+  const authenticated = useSelector((state) => isAuthenticated(state));
   const { roles } = extraData;
   const { activeRoles } = props;
-  return activeRoles && roles && isAuthorized(roles, activeRoles) ? (
-    <ConnectedPrivateRoute {...CPRProps} />
-  ) : (
-    <UnauthorizedPage title={lang.FORBIDDEN_PAGE_STATUS} />
-  );
+  if (authenticated) {
+    if (activeRoles && roles && isAuthorized(roles, activeRoles)) {
+      return <ConnectedPrivateRoute {...CPRProps} />;
+    } else {
+      return <UnauthorizedPage title={lang.FORBIDDEN_PAGE_STATUS} />;
+    }
+  }
+  return <ConnectedPrivateRoute {...CPRProps} />;
 };
 
 /** Util wrapper around Route for rendering components

--- a/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
+++ b/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
@@ -90,6 +90,38 @@ describe('componentUtils', () => {
     wrapper.unmount();
   });
 
+  it('should not redirect to unauthorized page if not autenticated', async () => {
+    const MockComponent = (props: any) => {
+      return <UserList {...props} keycloakBaseURL={KEYCLOAK_API_BASE_URL} />;
+    };
+    const props = {
+      exact: true,
+      redirectPath: '/login',
+      disableLoginProtection: false,
+      path: '/admin',
+      authenticated: false,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: `/admin`, hash: '', search: '', state: {} }]}>
+          <PrivateComponent
+            {...props}
+            component={MockComponent}
+            activeRoles={['ROLE_VIEW_KEYCLOAK_USERS']}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    await act(async () => {
+      await flushPromises();
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    wrapper.update();
+    expect(wrapper.exists(MockComponent)).toBeFalsy();
+    expect(toJson(wrapper.find('UnauthorizedPage'))).toBeFalsy();
+    wrapper.unmount();
+  });
+
   it('Show Unauthorized Page if role doesnt have sufficient permissions', async () => {
     const MockComponent = (props: any) => {
       return <UserList {...props} keycloakBaseURL={KEYCLOAK_API_BASE_URL} />;


### PR DESCRIPTION
This PR addresses #560 

Issue: 
- Private route was checking only user is authorised or not by getting values from store.
- On reloading the page, store gets updated and get back to its default state,

Fix:
- Added authenticated check, if user is authenticated then check authorisation else redirect to Login.