### PR TITLE
fix eternal spinner bug when re-visiting the location unit list page

### DIFF
--- a/packages/location-management/src/components/LocationUnitList/index.tsx
+++ b/packages/location-management/src/components/LocationUnitList/index.tsx
@@ -94,7 +94,7 @@ export const LocationUnitList: React.FC<Props> = (props: Props) => {
   const dispatch = useDispatch();
   const treeData = useSelector((state) => getAllHierarchiesArray(state));
   const locationUnits = useSelector((state) => getLocationUnitsArray(state));
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
   const [tableData, setTableData] = useState<TableData[]>([]);
   const [detail, setDetail] = useState<LocationDetailData | 'loading' | null>(null);
   const [currentClicked, setCurrentClicked] = useState<ParsedHierarchyNode | null>(null);
@@ -122,6 +122,7 @@ export const LocationUnitList: React.FC<Props> = (props: Props) => {
   // Function used to parse data from ParsedHierarchyNode to Tree Data
   useEffect(() => {
     if (!treeData.length && locationUnits.length) {
+      setLoading(true);
       getHierarchy(locationUnits, opensrpBaseURL)
         .then((hierarchy: RawOpenSRPHierarchy[]) => {
           const allhierarchy = hierarchy.map((hier) => generateJurisdictionTree(hier).model);

--- a/packages/location-management/src/components/LocationUnitList/tests/index.test.tsx
+++ b/packages/location-management/src/components/LocationUnitList/tests/index.test.tsx
@@ -412,4 +412,48 @@ describe('location-management/src/components/LocationUnitList', () => {
     expect(wrapper.find('LocationUnitDetail')).toHaveLength(0);
     wrapper.unmount();
   });
+
+  it('do not show spinner if hierarchies in state', async () => {
+    fetch.once(JSON.stringify(baseLocationUnits));
+    fetch.once(JSON.stringify(rawHierarchy[0]));
+    fetch.once(JSON.stringify(rawHierarchy[1]));
+    fetch.once(JSON.stringify(rawHierarchy[2]));
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <LocationUnitList opensrpBaseURL={baseURL} />
+        </Router>
+      </Provider>
+    );
+
+    // shows spinner before hierarchies are fetched and dispatched
+    expect(toJson(wrapper.find('.ant-spin'))).toBeTruthy();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // no spinner after hierarchies are dispatched
+    expect(toJson(wrapper.find('.ant-spin'))).toBeFalsy();
+    // shows layout content instead
+    expect(toJson(wrapper.find('.layout-content'))).toBeTruthy();
+
+    // unmount component
+    wrapper.unmount();
+
+    // no spinner or layout
+    expect(toJson(wrapper.find('.ant-spin'))).toBeFalsy();
+    expect(toJson(wrapper.find('.layout-content'))).toBeFalsy();
+
+    // remount
+    wrapper.mount();
+
+    // no spinner
+    expect(toJson(wrapper.find('.ant-spin'))).toBeFalsy();
+    expect(toJson(wrapper.find('.layout-content'))).toBeTruthy();
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION

Fixes #566 

There's no way to unit test this behaviour