### PR TITLE
Add docker build push ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,9 +46,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v1
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -86,7 +85,7 @@ jobs:
         id: docker_build
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+#          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,103 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `master` tag.
+    # See also https://github.com/crazy-max/ghaction-docker-meta#basic
+    branches:
+      - master
+      - add-docker-build-push-ci
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  pull_request:
+    # Run Tests when changes are made to the Docker file
+    paths:
+      - 'Dockerfile'
+
+  workflow_dispatch:
+    inputs:
+      customTag:
+        description: "Includes the specified tag to docker image tags"
+        required: false
+
+jobs:
+  # Run image build test
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Run Build tests
+        run: docker build . --file Dockerfile
+
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: opensrp/web
+          tag-custom: ${{ github.event.inputs.customTag }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Push to Docker Image Repositories
+        uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,6 @@ on:
     # See also https://github.com/crazy-max/ghaction-docker-meta#basic
     branches:
       - master
-      - add-docker-build-push-ci
 
     # Publish `v1.2.3` tags as releases.
     tags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN chown -R node .
 USER node
 
 RUN cp /project/app/.env.sample /project/app/.env \
-      && yarn
+      && yarn --network-timeout 100000
+# network timeout added to fix an issue with build on arm64 arch https://github.com/yarnpkg/yarn/issues/4890
 
 USER root
 RUN chown -R node .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN chown -R node .
 USER node
 
 RUN cp /project/app/.env.sample /project/app/.env \
-      && yarn --network-timeout 100000
-# network timeout added to fix an issue with build on arm64 arch https://github.com/yarnpkg/yarn/issues/4890
+      && yarn
 
 USER root
 RUN chown -R node .


### PR DESCRIPTION
Things noticed during docker image build.

- The build and push for amd64 images work well with no issues, on the other hand arm64 images need a change on the Dockerfile to include `--network-timeout` since there seems to be a network connection issues on arm64 arch refer to https://github.com/nodejs/docker-node/issues/1335
- Build times for amd64 ~ 14min but for amd64 and arm64 it takes ~ 1hr refer to https://github.com/opensrp/web/actions/workflows/docker-publish.yml.