### PR TITLE
cancel on user edit should take to users url not user/list url

### DIFF
--- a/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, FC } from 'react';
 import { useHistory } from 'react-router';
 import { Button, Col, Row, Form, Select, Input, Radio } from 'antd';
 import { KeycloakUser, Practitioner, UserGroup } from '../../../ducks/user';
-import { URL_USER } from '../../../constants';
 import lang from '../../../lang';
 import { submitForm } from './utils';
 import { Dictionary } from '@onaio/utils';

--- a/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
@@ -145,7 +145,7 @@ const UserForm: FC<UserFormProps> = (props: UserFormProps) => {
             <Button type="primary" htmlType="submit" className="create-user">
               {isSubmitting ? lang.SAVING : lang.SAVE}
             </Button>
-            <Button onClick={() => history.push(URL_USER)} className="cancel-user">
+            <Button onClick={() => history.goBack()} className="cancel-user">
               {lang.CANCEL}
             </Button>
           </Form.Item>

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/index.test.tsx
@@ -19,6 +19,7 @@ import { act } from 'react-dom/test-utils';
 import { OPENSRP_API_BASE_URL } from '@opensrp/server-service';
 import { Router } from 'react-router';
 import { Form } from 'antd';
+import { URL_USER } from '../../../../constants';
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -351,7 +352,7 @@ describe('components/forms/UserForm', () => {
     wrapper.update();
     const button = wrapper.find('button.cancel-user');
     button.simulate('click');
-    expect(history.location.pathname).toEqual('/admin/users');
+    expect(history.location.pathname).toEqual(URL_USER);
   });
 
   it('render correct user name in header', async () => {


### PR DESCRIPTION
_Right Now pressing cancel button on user edit takes to url with user/list which was removed by pr Sidemenu Refractor_

_Ideally the back button should take to history.goback rather than some specific url_

Closes #620 