### PR TITLE
659 fix team members on edit bug

### DIFF
--- a/packages/team-management/package.json
+++ b/packages/team-management/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@onaio/redux-reducer-registry": "^0.0.9",
+    "@onaio/utils": "^0.0.1",
     "@opensrp/store": "^0.0.9",
     "@types/uuid": "8.3.0",
     "i18next-parser": "^3.5.0"

--- a/packages/team-management/src/components/TeamsAddEdit/Form.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/Form.tsx
@@ -20,6 +20,7 @@ export interface FormField {
   name: string;
   active: boolean;
   practitioners: string[];
+  practitionersList: Practitioner[];
 }
 
 interface Props {
@@ -154,7 +155,12 @@ export async function setTeam(
 
 export const Form: React.FC<Props> = (props: Props) => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const initialValue = props.initialValue ?? { active: true, name: '', practitioners: [] };
+  const initialValue = props.initialValue ?? {
+    active: true,
+    name: '',
+    practitioners: [],
+    practitionersList: [],
+  };
 
   return (
     <AntdForm
@@ -189,7 +195,7 @@ export const Form: React.FC<Props> = (props: Props) => {
         tooltip={lang.TIP_REQUIRED_FIELD}
       >
         <Select allowClear mode="multiple" placeholder={lang.SELECT_PRACTITIONER}>
-          {props.practitioner.map((practitioner) => (
+          {initialValue.practitionersList.map((practitioner) => (
             <Select.Option key={practitioner.identifier} value={practitioner.identifier}>
               {practitioner.name}
             </Select.Option>

--- a/packages/team-management/src/components/TeamsAddEdit/index.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/index.tsx
@@ -62,6 +62,7 @@ function setupInitialValue(
       setInitialValue({
         ...response,
         practitioners: response.practitioners.map((prac) => prac.identifier),
+        practitionersList: response.practitioners,
       });
     })
     .catch(() => sendErrorNotification(langObj.ERROR_OCCURRED));

--- a/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
@@ -28,6 +28,29 @@ jest.mock('uuid', () => {
 });
 
 describe('Team-management/TeamsAddEdit/Form', () => {
+  const members = [
+    {
+      identifier: '3',
+      active: false,
+      name: 'prac one',
+      userId: '3',
+      username: 'prac_one',
+    },
+    {
+      identifier: '4',
+      active: false,
+      name: 'Practitioner Two',
+      userId: '4',
+      username: 'prac_two',
+    },
+    {
+      identifier: '5',
+      active: false,
+      name: 'Practitioner One',
+      userId: '5',
+      username: 'practitioner_one',
+    },
+  ];
   afterEach(() => {
     fetch.resetMocks();
   });
@@ -126,6 +149,7 @@ describe('Team-management/TeamsAddEdit/Form', () => {
       active: true,
       name: 'New team name',
       practitioners: [],
+      practitionersList: [],
     });
 
     await act(async () => {
@@ -203,7 +227,12 @@ describe('Team-management/TeamsAddEdit/Form', () => {
       jest.fn,
       practitioners,
       intialValue,
-      { active: false, name: 'new name', practitioners: ['3', '4', '5'] },
+      {
+        active: false,
+        name: 'new name',
+        practitioners: ['3', '4', '5'],
+        practitionersList: members,
+      },
       id
     );
 
@@ -287,7 +316,12 @@ describe('Team-management/TeamsAddEdit/Form', () => {
       jest.fn,
       practitioners,
       intialValue,
-      { active: false, name: 'new name', practitioners: ['3', '4', '5'] },
+      {
+        active: false,
+        name: 'new name',
+        practitioners: ['3', '4', '5'],
+        practitionersList: members,
+      },
       id
     );
 

--- a/packages/team-management/src/components/TeamsAddEdit/tests/fixtures.ts
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/fixtures.ts
@@ -79,6 +79,7 @@ export const intialValue: FormField = {
   name: team.name,
   active: team.active,
   practitioners: practitioners.slice(0, 3).map((prac) => prac.identifier),
+  practitionersList: practitioners.slice(0, 3),
 };
 
 export const teamPost: OrganizationPOST = {

--- a/packages/team-management/src/components/TeamsAddEdit/tests/fixtures.ts
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/fixtures.ts
@@ -75,6 +75,30 @@ export const practitioners: Practitioner[] = [
   },
 ];
 
+export const members = [
+  {
+    identifier: '3',
+    active: false,
+    name: 'prac one',
+    userId: '3',
+    username: 'prac_one',
+  },
+  {
+    identifier: '4',
+    active: false,
+    name: 'Practitioner Two',
+    userId: '4',
+    username: 'prac_two',
+  },
+  {
+    identifier: '5',
+    active: false,
+    name: 'Practitioner One',
+    userId: '5',
+    username: 'practitioner_one',
+  },
+];
+
 export const intialValue: FormField = {
   name: team.name,
   active: team.active,

--- a/packages/team-management/src/components/TeamsView/index.tsx
+++ b/packages/team-management/src/components/TeamsView/index.tsx
@@ -76,7 +76,6 @@ export const TeamsView: React.FC<Props> = (props: Props) => {
   const [value, setValue] = useState('');
   const [filter, setfilterData] = useState<TableData[] | null>(null);
   const { opensrpBaseURL } = props;
-
   useEffect(() => {
     if (isLoading) {
       const serve = new OpenSRPService(TEAMS_GET, opensrpBaseURL);


### PR DESCRIPTION
- Fix team members list to display practitioner name instead of UUID on team edit page
closes #659 

![image](https://user-images.githubusercontent.com/19689992/119463624-9b8ef900-bd4a-11eb-9ea2-79572f3ac2f5.png)
