### PR TITLE
use default practitioner name instead of identifier

### DIFF
--- a/packages/team-management/src/components/TeamsAddEdit/Form.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/Form.tsx
@@ -194,12 +194,7 @@ export const Form: React.FC<Props> = (props: Props) => {
         label={lang.TEAM_MEMBERS}
         tooltip={lang.TIP_REQUIRED_FIELD}
       >
-        <Select
-          allowClear
-          mode="multiple"
-          placeholder={lang.SELECT_PRACTITIONER}
-          value={initialValue.practitionersList.map((practitioner) => practitioner.name)}
-        >
+        <Select allowClear mode="multiple" placeholder={lang.SELECT_PRACTITIONER}>
           {props.practitioners.map((practitioner) => (
             <Select.Option key={practitioner.identifier} value={practitioner.identifier}>
               {practitioner.name}

--- a/packages/team-management/src/components/TeamsAddEdit/index.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/index.tsx
@@ -68,7 +68,7 @@ function setupInitialValue(
     .then((response) => {
       setInitialValue({
         ...response,
-        practitioners: response.practitioners.map((practitioner) => practitioner.name),
+        practitioners: response.practitioners.map((practitioner) => practitioner.identifier),
         practitionersList: response.practitioners,
       });
     })

--- a/packages/team-management/src/components/TeamsAddEdit/index.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/index.tsx
@@ -68,7 +68,7 @@ function setupInitialValue(
     .then((response) => {
       setInitialValue({
         ...response,
-        practitioners: response.practitioners.map((prac) => prac.identifier),
+        practitioners: response.practitioners.map((practitioner) => practitioner.name),
         practitionersList: response.practitioners,
       });
     })

--- a/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
@@ -480,6 +480,16 @@ describe('Team-management/TeamsAddEdit/Form', () => {
       '7',
     ]);
 
+    // expect default values to match existing practitioners
+
+    // get all practitioner objects matching default values
+    const defaultPractitioners = practitioners.filter((practitioner) =>
+      (values as readonly string[]).includes(practitioner.identifier)
+    );
+
+    // expect object with names whose identifiers match default values
+    expect(defaultPractitioners).toMatchSnapshot('default practitioner objects');
+
     // simulate change
     // add '6' to default values
     practitionersSelect.simulate('change', {

--- a/packages/team-management/src/components/TeamsAddEdit/tests/__snapshots__/Form.test.tsx.snap
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/__snapshots__/Form.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Team-management/TeamsAddEdit/Form renders with default team members with option to add: default practitioner objects 1`] = `
+Array [
+  Object {
+    "active": true,
+    "identifier": "1",
+    "name": "prac two",
+    "userId": "1",
+    "username": "prac2",
+  },
+  Object {
+    "active": false,
+    "identifier": "2",
+    "name": "prac one",
+    "userId": "2",
+    "username": "prac_1",
+  },
+  Object {
+    "active": false,
+    "identifier": "3",
+    "name": "prac one",
+    "userId": "3",
+    "username": "prac_one",
+  },
+]
+`;

--- a/packages/team-management/src/components/TeamsAddEdit/tests/index.test.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/index.test.tsx
@@ -349,5 +349,14 @@ describe('Team-management/TeamsAddEdit/TeamsAddEdit', () => {
 
     // expect antd select options text to equal practitioners filtered for only active users
     expect(options.map((opt) => opt.text())).toStrictEqual(filteredPractitionerNames);
+
+    // get default displayed practitioners
+    const defaultPractitioners = practitionersSelect.find('.ant-select-selection-item-content');
+    // expect them to match default active practitioners
+    expect(defaultPractitioners.map((opt) => opt.text())).toStrictEqual([
+      'prac two',
+      'Benjamin Mulyungi',
+      'test admin',
+    ]);
   });
 });


### PR DESCRIPTION
default team members to names instead of identifiers.

The practitioners belonging to a team default's to a list of all practitioners identifiers who belong to that team. This PR changes that to a list of all practitioners names belonging to the team.
![problem](https://user-images.githubusercontent.com/10197807/121335445-4397eb00-c923-11eb-9378-a145fddc9bb8.png)
