### PR TITLE
694 disable and un-assign practitioner on user delete

### DIFF
--- a/packages/keycloak-user-management/src/components/UserList/TableActions/index.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/index.tsx
@@ -13,6 +13,7 @@ import { TableData } from '..';
 export interface Props {
   removeKeycloakUsersCreator: typeof removeKeycloakUsers;
   keycloakBaseURL: string;
+  opensrpBaseURL: string;
   record: TableData;
   isLoadingCallback: (loading: boolean) => void;
   extraData: Dictionary;
@@ -29,6 +30,7 @@ const TableActions = (props: Props): JSX.Element => {
     record,
     removeKeycloakUsersCreator,
     keycloakBaseURL,
+    opensrpBaseURL,
     isLoadingCallback,
     extraData,
   } = props;
@@ -41,7 +43,13 @@ const TableActions = (props: Props): JSX.Element => {
           okText="Yes"
           cancelText="No"
           onConfirm={() =>
-            deleteUser(removeKeycloakUsersCreator, keycloakBaseURL, record.id, isLoadingCallback)
+            deleteUser(
+              removeKeycloakUsersCreator,
+              keycloakBaseURL,
+              opensrpBaseURL,
+              record.id,
+              isLoadingCallback
+            )
           }
         >
           {user_id &&

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
@@ -38,7 +38,14 @@ export const deleteUser = async (
     OPENSRP_CREATE_PRACTITIONER_ENDPOINT,
     userId,
     opensrpBaseURL
-  );
+  ).catch(() => {
+    sendErrorNotification(langObj.ERROR_OCCURED);
+    // stop loader
+    isLoadingCallback(false);
+    return undefined;
+  });
+
+  if (!practitioner) return;
 
   // service class to delete keycloak user
   const serviceDelete = new KeycloakService(`${KEYCLOAK_URL_USERS}/${userId}`, keycloakBaseURL);
@@ -121,7 +128,5 @@ async function unassignAndDeactivatePractitioner(
       ...practitioner,
       active: false,
     }),
-  ]).catch((err) => {
-    throw err;
-  });
+  ]);
 }

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
@@ -30,6 +30,9 @@ export const deleteUser = async (
   isLoadingCallback: (loading: boolean) => void,
   langObj: Lang = lang
 ) => {
+  // start loader
+  isLoadingCallback(true);
+
   // get tied practitioner from base user Id
   const practitioner = await getPractitionerByUserId(
     OPENSRP_CREATE_PRACTITIONER_ENDPOINT,
@@ -53,13 +56,16 @@ export const deleteUser = async (
   ])
     .then(() => {
       removeKeycloakUsersCreator();
-      isLoadingCallback(true);
       sendSuccessNotification(langObj.USER_DELETED_SUCCESSFULLY);
       sendSuccessNotification(langObj.PRACTITIONER_UNASSIGNED_SUCCESSFULLY);
       sendSuccessNotification(langObj.PRACTITIONER_DEACTIVATED_SUCCESSFULLY);
     })
     .catch((_: Error) => {
       sendErrorNotification(langObj.ERROR_OCCURED);
+    })
+    .finally(() => {
+      // stop loader
+      isLoadingCallback(false);
     });
 };
 

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
@@ -1,35 +1,121 @@
 import { KeycloakService } from '@opensrp/keycloak-service';
+import { OpenSRPService } from '@opensrp/react-utils';
 import { sendErrorNotification, sendSuccessNotification } from '@opensrp/notifications';
 import { removeKeycloakUsers } from '../../../ducks/user';
-import { KEYCLOAK_URL_USERS } from '../../../constants';
+import {
+  KEYCLOAK_URL_USERS,
+  PRACTITIONER,
+  OPENSRP_CREATE_PRACTITIONER_ENDPOINT,
+  DELETE_PRACTITIONER_ROLE,
+} from '../../../constants';
 import lang, { Lang } from '../../../lang';
+import { Practitioner } from '@opensrp/team-management';
 
 /**
- * Delete keycloak user
+ * Delete keycloak user and practitioner
  *
  * @param {Function} removeKeycloakUsersCreator - remove users action creator
  * @param {string} keycloakBaseURL - keycloak api base URL
+ * @param opensrpBaseURL - opensrp api base url
  * @param {string} userId - id of user to be deleted
  * @param {Function} isLoadingCallback - callback function that sets loading state
  * @param {Lang} langObj - lang
  * @returns {void}
  */
-export const deleteUser = (
+export const deleteUser = async (
   removeKeycloakUsersCreator: typeof removeKeycloakUsers,
   keycloakBaseURL: string,
+  opensrpBaseURL: string,
   userId: string,
   isLoadingCallback: (loading: boolean) => void,
   langObj: Lang = lang
-): void => {
+) => {
+  // get tied practitioner from base user Id
+  const practitioner = await getPractitionerByUserId(
+    OPENSRP_CREATE_PRACTITIONER_ENDPOINT,
+    userId,
+    opensrpBaseURL
+  );
+
+  // service class to delete keycloak user
   const serviceDelete = new KeycloakService(`${KEYCLOAK_URL_USERS}/${userId}`, keycloakBaseURL);
-  serviceDelete
-    .delete()
+
+  return Promise.all([
+    // delete keycloak user
+    serviceDelete.delete(),
+    // unassign and deactivate the tied practitioner when you delete the base user
+    unassignAndDeactivatePractitioner(
+      DELETE_PRACTITIONER_ROLE,
+      PRACTITIONER,
+      practitioner,
+      opensrpBaseURL
+    ),
+  ])
     .then(() => {
       removeKeycloakUsersCreator();
       isLoadingCallback(true);
       sendSuccessNotification(langObj.USER_DELETED_SUCCESSFULLY);
+      sendSuccessNotification(langObj.PRACTITIONER_UNASSIGNED_SUCCESSFULLY);
+      sendSuccessNotification(langObj.PRACTITIONER_DEACTIVATED_SUCCESSFULLY);
     })
     .catch((_: Error) => {
       sendErrorNotification(langObj.ERROR_OCCURED);
     });
 };
+
+/**
+ * function to query a tied practitioner from a userId - practitioner created from that user
+ *
+ * @param practitionerEndpoint - opensrp practitioner end point
+ * @param userId  - the user id to get practitioner for
+ * @param opensrpBaseURL - opensrp base url
+ * @returns {Practitioner} - the tied practitioner
+ */
+async function getPractitionerByUserId(
+  practitionerEndpoint: string,
+  userId: string,
+  opensrpBaseURL: string
+) {
+  // get practitioner from userId
+  const openSrpService = new OpenSRPService(practitionerEndpoint + '/' + userId, opensrpBaseURL);
+  const practitioner: Practitioner = await openSrpService.list();
+  return practitioner;
+}
+
+/**
+ * unassign and deactivate a practitioner
+ *
+ * @param deletePractitionerRoleEndpoint - opensrp endpoint to delete practitioner role
+ * @param deactivatePractitionerEndpoint - opensrp endpoint to deactivate practitioner
+ * @param practitioner - practitioner to modify
+ * @param opensrpBaseURL - opensrp base url
+ * @returns Promise to unassign and deactivate a practitioner
+ */
+async function unassignAndDeactivatePractitioner(
+  deletePractitionerRoleEndpoint: string,
+  deactivatePractitionerEndpoint: string,
+  practitioner: Practitioner,
+  opensrpBaseURL: string
+) {
+  // delete practitioner role
+  const openSrpDeletePractitionerRole = new OpenSRPService(
+    deletePractitionerRoleEndpoint + practitioner.identifier,
+    opensrpBaseURL
+  );
+
+  // deactivate practitioner
+  const openSrpDeactivatePractitioner = new OpenSRPService(
+    deactivatePractitionerEndpoint,
+    opensrpBaseURL
+  );
+
+  return Promise.all([
+    openSrpDeletePractitionerRole.delete(),
+    openSrpDeactivatePractitioner.update({
+      ...practitioner,
+      active: false,
+    }),
+  ]).catch((err) => {
+    throw err;
+  });
+}

--- a/packages/keycloak-user-management/src/components/UserList/index.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/index.tsx
@@ -48,6 +48,7 @@ export interface Props {
   removeKeycloakUsersCreator: typeof removeKeycloakUsers;
   keycloakUsers: KeycloakUser[];
   keycloakBaseURL: string;
+  opensrpBaseURL: string;
   extraData: Dictionary;
   usersPageSize: number;
 }
@@ -59,6 +60,7 @@ export const defaultProps = {
   removeKeycloakUsersCreator: removeKeycloakUsers,
   keycloakUsers: [],
   keycloakBaseURL: '',
+  opensrpBaseURL: '',
   extraData: {},
   usersPageSize: 20,
 };
@@ -82,6 +84,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
     removeKeycloakUsersCreator,
     keycloakUsers,
     keycloakBaseURL,
+    opensrpBaseURL,
     extraData,
     usersPageSize,
   } = props;
@@ -198,6 +201,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
                   const tableActionsProps = {
                     removeKeycloakUsersCreator,
                     keycloakBaseURL,
+                    opensrpBaseURL,
                     isLoadingCallback,
                     record,
                     extraData,

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -8,6 +8,7 @@ import {
   URL_USER,
   URL_USER_CREDENTIALS,
   KEYCLOAK_URL_USER_GROUPS,
+  PRACTITIONER,
 } from '../../../constants';
 import { OpenSRPService } from '@opensrp/react-utils';
 import lang, { Lang } from '../../../lang';
@@ -39,7 +40,7 @@ export const createOrEditPractitioners = async (
   values: FormFields,
   langObj: Lang = lang
 ) => {
-  const practitionersService = new OpenSRPService('practitioner', baseURL);
+  const practitionersService = new OpenSRPService(PRACTITIONER, baseURL);
 
   // initialize values for creating a practitioner
   let requestType: 'update' | 'create' = 'create';

--- a/packages/keycloak-user-management/src/constants.ts
+++ b/packages/keycloak-user-management/src/constants.ts
@@ -25,7 +25,11 @@ export const KEYCLOAK_URL_RESET_PASSWORD = '/reset-password';
 export const KEYCLOAK_URL_REQUIRED_USER_ACTIONS = '/authentication/required-actions/';
 
 // OpenSRP API strings
-export const OPENSRP_CREATE_PRACTITIONER_ENDPOINT = 'practitioner/user';
+export const PRACTITIONER = 'practitioner';
+export const OPENSRP_CREATE_PRACTITIONER_ENDPOINT = `${PRACTITIONER}/user`;
+
+// practitioner role
+export const DELETE_PRACTITIONER_ROLE = 'practitionerRole/delete/';
 
 // Query patams
 export const SEARCH_QUERY_PARAM = 'searchQuery';

--- a/packages/keycloak-user-management/src/lang.ts
+++ b/packages/keycloak-user-management/src/lang.ts
@@ -33,6 +33,12 @@ function fill() {
   lang.PRACTITIONER_UPDATED_SUCCESSFULLY = i18n.t(`Practitioner updated successfully`, {
     ns: namespace,
   });
+  lang.PRACTITIONER_DEACTIVATED_SUCCESSFULLY = i18n.t(`Practitioner deactivated successfully`, {
+    ns: namespace,
+  });
+  lang.PRACTITIONER_UNASSIGNED_SUCCESSFULLY = i18n.t(`Practitioner unassigned successfully`, {
+    ns: namespace,
+  });
   lang.ROLES_UPDATED_SUCCESSFULLY = i18n.t(`Role Mappings Updated Successfully`, { ns: namespace });
   lang.REALM_ROLES = i18n.t(`Realm Roles`, { ns: namespace });
   lang.AVAILABLE_ROLES = i18n.t(`Available Roles`, { ns: namespace });


### PR DESCRIPTION
- closes #694 
- add deactivating a practitioner and un-assigning them from teams after the tied user is deleted