### PR TITLE
Unique key prop for same component

### DIFF
--- a/packages/react-utils/src/helpers/componentUtils.tsx
+++ b/packages/react-utils/src/helpers/componentUtils.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { Route, RouteProps, RouteComponentProps } from 'react-router';
+import { Route, RouteProps, RouteComponentProps, useLocation } from 'react-router';
 import { useSelector } from 'react-redux';
 import { getExtraData, isAuthenticated } from '@onaio/session-reducer';
 import { getAllConfigs } from '@opensrp/pkg-config';
@@ -36,18 +36,20 @@ export const PrivateComponent = (props: ComponentProps) => {
     opensrpBaseURL: configs.opensrpBaseURL,
     fhirBaseURL: configs.fhirBaseURL,
   };
+  // get current pathname - to be passed as unique key to ConnectedPrivateRoute
+  const { pathname } = useLocation();
   const extraData = useSelector((state) => getExtraData(state));
   const authenticated = useSelector((state) => isAuthenticated(state));
   const { roles } = extraData;
   const { activeRoles } = props;
   if (authenticated) {
     if (activeRoles && roles && isAuthorized(roles, activeRoles)) {
-      return <ConnectedPrivateRoute {...CPRProps} />;
+      return <ConnectedPrivateRoute {...CPRProps} key={pathname} />;
     } else {
       return <UnauthorizedPage title={lang.FORBIDDEN_PAGE_STATUS} />;
     }
   }
-  return <ConnectedPrivateRoute {...CPRProps} />;
+  return <ConnectedPrivateRoute {...CPRProps} key={pathname} />;
 };
 
 /** Util wrapper around Route for rendering components
@@ -57,7 +59,14 @@ export const PrivateComponent = (props: ComponentProps) => {
  */
 
 export const PublicComponent = ({ component: Component, ...rest }: Partial<ComponentProps>) => {
-  return <Route {...rest} component={(props: RouteComponentProps) => <Component {...props} />} />;
+  // get current pathname - to be passed as unique key to ConnectedPrivateRoute
+  const { pathname } = useLocation();
+  return (
+    <Route
+      {...rest}
+      component={(props: RouteComponentProps) => <Component {...props} key={pathname} />}
+    />
+  );
 };
 
 /** Util function to check if user is authorized to access a particular page

--- a/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
+++ b/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/camelcase */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { history } from '@onaio/connected-reducer-registry';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Router } from 'react-router';
 import { store } from '@opensrp/store';
 import * as componentUtils from '../componentUtils';
 import { UserList } from '@opensrp/user-management';
@@ -14,6 +14,7 @@ import { Resource404 } from '../../components/Resource404';
 import { KEYCLOAK_API_BASE_URL } from '@opensrp/keycloak-service';
 import { authenticateUser } from '@onaio/session-reducer';
 import flushPromises from 'flush-promises';
+import fetch from 'jest-fetch-mock';
 
 const { PublicComponent, PrivateComponent, isAuthorized } = componentUtils;
 
@@ -164,5 +165,120 @@ describe('componentUtils', () => {
       ['unauthorized']
     );
     expect(isUserAuthorized).toBeFalsy();
+  });
+
+  it('Updates state on route/pathname changes for same component', async () => {
+    store.dispatch(
+      authenticateUser(
+        true,
+        {
+          email: 'test@gmail.com',
+          name: 'This Name',
+          username: 'tHat Part',
+        },
+        {
+          roles: ['ROLE_VIEW_KEYCLOAK_USERS'],
+          username: 'superset-user',
+          user_id: 'cab07278-c77b-4bc7-b154-bcbf01b7d35b',
+        }
+      )
+    );
+
+    // mock component with internal state change
+    const MockComponent = (props: {
+      match: {
+        params: {
+          id: string;
+        };
+      };
+    }) => {
+      // get user id from url
+      const {
+        match: {
+          params: { id },
+        },
+      } = props;
+      const [someState, setSomeState] = useState<{
+        firstName: string;
+        lastName: string;
+      }>({
+        firstName: '',
+        lastName: '',
+      });
+
+      // update state on fetch - internal data change on mount
+      useEffect(() => {
+        fetch(`http://example.com/users/${id}`)
+          .then((response) => response.json())
+          .then((data) => setSomeState(data))
+          .catch((err) => {
+            throw err;
+          });
+      }, [id]);
+
+      return <p className="mockClassName">{`${someState.firstName} ${someState.lastName}`}</p>;
+    };
+
+    // mock re-fetch on re-mount
+    fetch
+      .mockOnce(
+        JSON.stringify({
+          firstName: 'Anon',
+          lastName: 'Ops',
+        })
+      )
+      .mockOnce(
+        JSON.stringify({
+          firstName: 'Anon',
+          lastName: 'Central',
+        })
+      );
+
+    const props = {
+      exact: true,
+      redirectPath: '/login',
+      disableLoginProtection: false,
+      path: '/admin/users/:id',
+      authenticated: true,
+    };
+
+    // start with user with id 1
+    history.push('/admin/users/1');
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <PrivateComponent
+            {...props}
+            component={MockComponent}
+            activeRoles={['ROLE_VIEW_KEYCLOAK_USERS']}
+          />
+        </Router>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('.mockClassName').text()).toMatchInlineSnapshot(`"Anon Ops"`);
+
+    // simulate navigation - similar url but different pathname (id)
+    history.push('/admin/users/2');
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // expect change to result of second fetch
+    expect(wrapper.find('.mockClassName').text()).toMatchInlineSnapshot(`"Anon Central"`);
+
+    // expect both fetch calls
+    expect(fetch.mock.calls).toMatchObject([
+      ['http://example.com/users/1'],
+      ['http://example.com/users/2'],
+    ]);
   });
 });

--- a/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
+++ b/packages/react-utils/src/helpers/tests/componentUtils.test.tsx
@@ -275,10 +275,6 @@ describe('componentUtils', () => {
     // expect change to result of second fetch
     expect(wrapper.find('.mockClassName').text()).toMatchInlineSnapshot(`"Anon Central"`);
 
-    // expect both fetch calls
-    expect(fetch.mock.calls).toMatchObject([
-      ['http://example.com/users/1'],
-      ['http://example.com/users/2'],
-    ]);
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
- fixes #715 
- add a unique key prop to routes that render the same component on url param change. This makes them update internal state on every render. See discussion [here](https://github.com/opensrp/web/pull/718) 