### PR TITLE
Revert: Get keycloak user id from post request reponse

### DIFF
--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/index.test.tsx
@@ -251,7 +251,7 @@ describe('components/forms/UserForm', () => {
 
     expect(JSON.parse((fetch.mock.calls[0][1] as Dictionary).body)).toEqual({
       firstName: 'Test',
-      id: mockId,
+      id: '',
       lastName: 'One',
       username: 'TestOne',
       email: 'testone@gmail.com',

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -573,6 +573,12 @@ describe('forms/utils/submitForm', () => {
   });
 
   it('creates active practitioner on keycloak user creation', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ id: 1 }), {
+      status: 200,
+      headers: {
+        Location: `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}`,
+      },
+    });
     submitForm(
       // initialize values for new user creation
       { ...value, id: undefined, userGroups: undefined },
@@ -603,7 +609,7 @@ describe('forms/utils/submitForm', () => {
           lastName: value.lastName,
           username: value.username,
           email: value.email,
-          id: mockV4,
+          id: '',
         },
       },
       {
@@ -613,7 +619,7 @@ describe('forms/utils/submitForm', () => {
           active: true,
           identifier: mockV4,
           name: `${value.firstName} ${value.lastName}`,
-          userId: mockV4,
+          userId: keycloakUserId,
           username: value.username,
         },
       },

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@opensrp/notifications', () => {
 });
 
 const mockV4 = '0b3a3311-6f5a-40dd-95e5-008001acebe1';
+const keycloakUserId = 'generatedKeycloakId';
 
 jest.mock('uuid', () => {
   const actualUUID = jest.requireActual('uuid');
@@ -54,6 +55,12 @@ describe('forms/utils/submitForm', () => {
   const id = mockV4;
 
   it('submits user creation correctly', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ id: 1 }), {
+      status: 200,
+      headers: {
+        Location: `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}`,
+      },
+    });
     const notificationSuccessMock = jest.spyOn(notifications, 'sendSuccessNotification');
     const historyPushMock = jest.spyOn(history, 'push');
 
@@ -68,15 +75,17 @@ describe('forms/utils/submitForm', () => {
     delete expectedKUser.userGroups;
     delete expectedKUser.practitioner;
 
+    // keycloak user payload
     expect(JSON.parse((fetch.mock.calls[0][1] as Dictionary).body)).toEqual({
       ...expectedKUser,
-      id: mockV4,
+      id: '',
     });
+    // practitioner payload
     expect(JSON.parse((fetch.mock.calls[1][1] as Dictionary).body)).toEqual({
       active: true,
       identifier: mockV4,
       name: `${value.firstName} ${value.lastName}`,
-      userId: mockV4,
+      userId: keycloakUserId,
       username: value.username,
     });
     expect(fetch.mock.calls).toMatchObject([
@@ -109,7 +118,7 @@ describe('forms/utils/submitForm', () => {
         },
       ],
       [
-        `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${mockV4}/groups/580c7fbf-c201-4dad-9172-1df9faf24936`,
+        `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}/groups/580c7fbf-c201-4dad-9172-1df9faf24936`,
         {
           'Cache-Control': 'no-cache',
           Pragma: 'no-cache',
@@ -123,7 +132,7 @@ describe('forms/utils/submitForm', () => {
         },
       ],
       [
-        `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${mockV4}/groups/2fffbc6a-528d-4cec-aa44-97ef65b9bba2`,
+        `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}/groups/2fffbc6a-528d-4cec-aa44-97ef65b9bba2`,
         {
           'Cache-Control': 'no-cache',
           Pragma: 'no-cache',
@@ -170,6 +179,12 @@ describe('forms/utils/submitForm', () => {
 
   it('correctly redirects to credentials page when practitioner is undefined (new user)', async () => {
     const historyPushMock = jest.spyOn(history, 'push');
+    fetch.mockResponseOnce(JSON.stringify({ id: 1 }), {
+      status: 200,
+      headers: {
+        Location: `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}`,
+      },
+    });
 
     submitForm(
       { ...value, practitioner: undefined },
@@ -381,7 +396,7 @@ describe('forms/utils/submitForm', () => {
           active: true,
           identifier: mockV4,
           name: `${value.firstName} ${value.lastName}`,
-          userId: keycloakUser.id,
+          userId: '',
           username: value.username,
         }),
         headers: {
@@ -506,6 +521,12 @@ describe('forms/utils/submitForm', () => {
   });
 
   it('updates practitioner values when user values update', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ id: 1 }), {
+      status: 200,
+      headers: {
+        Location: `https://keycloak-stage.smartregister.org/auth/admin/realms/opensrp-web-stage/users/${keycloakUserId}`,
+      },
+    });
     submitForm(
       { ...value, id: id, userGroups: undefined, practitioner: practitioner1 },
       keycloakBaseURL,

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -67,14 +67,14 @@ export const createOrEditPractitioners = async (
  * @param keycloakBaseURL -  base url for the keycloak instance
  * @param keycloakUserPayload - the keycloak user payload
  * @param isEditMode - whether editing or creating the keycloak user
- * @param callback - function called when user is successfully posted or updated
+ * @param updateGroupsAndPractitionerCallback - function called when user is successfully posted or updated
  * @param langObj - the translation store object
  */
 const createEditKeycloakUser = async (
   keycloakBaseURL: string,
   keycloakUserPayload: KeycloakUser,
   isEditMode: boolean,
-  callback: (id: string) => Promise<void>,
+  updateGroupsAndPractitionerCallback: (id: string) => Promise<void>,
   langObj = lang
 ) => {
   if (isEditMode) {
@@ -86,7 +86,9 @@ const createEditKeycloakUser = async (
       .update(keycloakUserPayload)
       .then(() => {
         sendSuccessNotification(langObj.MESSAGE_USER_EDITED);
-        callback(keycloakUserPayload.id).catch(() => sendErrorNotification(langObj.ERROR_OCCURED));
+        updateGroupsAndPractitionerCallback(keycloakUserPayload.id).catch(() =>
+          sendErrorNotification(langObj.ERROR_OCCURED)
+        );
       })
       .catch((error) => {
         throw error;
@@ -99,7 +101,9 @@ const createEditKeycloakUser = async (
       .then((res) => {
         sendSuccessNotification(langObj.MESSAGE_USER_CREATED);
         const keycloakUserId = getUserId(res);
-        callback(keycloakUserId).catch(() => sendErrorNotification(langObj.ERROR_OCCURED));
+        updateGroupsAndPractitionerCallback(keycloakUserId).catch(() =>
+          sendErrorNotification(langObj.ERROR_OCCURED)
+        );
       })
       .catch((error) => {
         throw error;


### PR DESCRIPTION
Revert: Get keycloak user id from post request reponse

Make fix to regression after wrong assumption that you could generate a uuid when creating a keycloakUser, 

closes :  #775 