### PR TITLE
push history to /keycloak-id instead of /practitioner-id

### DIFF
--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -152,7 +152,7 @@ describe('forms/utils/submitForm', () => {
       ['Practitioner created successfully'],
       ['User Group edited successfully'],
     ]);
-    expect(historyPushMock).toHaveBeenCalledWith(`/admin/users/credentials/${mockV4}`);
+    expect(historyPushMock).toHaveBeenCalledWith(`/admin/users/credentials/${keycloakUserId}`);
   });
 
   it('ensures error notification is not thrown when creating new user', async () => {
@@ -199,7 +199,7 @@ describe('forms/utils/submitForm', () => {
     });
     // ensure that redirect only happens once
     expect(historyPushMock).toHaveBeenCalledTimes(1);
-    expect(historyPushMock).toHaveBeenCalledWith(`/admin/users/credentials/${mockV4}`);
+    expect(historyPushMock).toHaveBeenCalledWith(`/admin/users/credentials/${keycloakUserId}`);
   });
 
   it('submits user edit correctly', async () => {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -58,7 +58,7 @@ export const createOrEditPractitioners = async (
     .catch((_: Error) => sendErrorNotification(langObj.ERROR_OCCURED))
     .then(() => sendSuccessNotification(successMessage));
 
-  if (!isEditMode) history.push(`${URL_USER_CREDENTIALS}/${payload.identifier}`);
+  if (!isEditMode) history.push(`${URL_USER_CREDENTIALS}/${payload.userId}`);
 };
 
 /**


### PR DESCRIPTION
- closes #800 
- push history to `/keycloak-id` instead of `/practitioner-id` (used to point to keycloak id when editing user)
- update tests 