### PR TITLE
Add return type in Fhirservice

### DIFF
--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -54,6 +54,7 @@
     "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
+    "@smile-cdr/fhirts": "1.2.5",
     "nock": "^13.0.6"
   },
   "author": "OpenSRP Engineering",

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -110,7 +110,7 @@ export class FHIRServiceClass<T = fhirclient.FHIR.Resource> {
   public async read(id: string) {
     const accessToken = await OpenSRPService.processAcessToken(this.accessTokenOrCallBack);
     const serve = FHIR.client(this.buildState(accessToken));
-    return serve.request(`${this.resourceType}/${id}`);
+    return serve.request<T>(`${this.resourceType}/${id}`);
   }
 
   public async delete(id: string) {

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -90,20 +90,20 @@ export class FHIRServiceClass<T = fhirclient.FHIR.Resource> {
   public async create(payload: T) {
     const accessToken = await OpenSRPService.processAcessToken(this.accessTokenOrCallBack);
     const serve = FHIR.client(this.buildState(accessToken));
-    return serve.create(payload);
+    return serve.create<T>(payload);
   }
 
   public async update(payload: T) {
     const accessToken = await OpenSRPService.processAcessToken(this.accessTokenOrCallBack);
     const serve = FHIR.client(this.buildState(accessToken));
-    return serve.update(payload);
+    return serve.update<T>(payload);
   }
 
   public async list(params: URLParams | null = null) {
     const accessToken = await OpenSRPService.processAcessToken(this.accessTokenOrCallBack);
     const queryStr = this.buildQueryParams(params);
     const serve = FHIR.client(this.buildState(accessToken));
-    return serve.request(queryStr);
+    return serve.request<T[]>(queryStr);
   }
 
   public async read(id: string) {

--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -17,6 +17,7 @@ import { getAllConfigs } from '@opensrp/pkg-config';
 import lang, { Lang } from '../lang';
 import FHIR from 'fhirclient';
 import { fhirclient } from 'fhirclient/lib/types';
+import { FHIRResponse } from '..';
 
 const configs = getAllConfigs();
 
@@ -103,7 +104,7 @@ export class FHIRServiceClass<T = fhirclient.FHIR.Resource> {
     const accessToken = await OpenSRPService.processAcessToken(this.accessTokenOrCallBack);
     const queryStr = this.buildQueryParams(params);
     const serve = FHIR.client(this.buildState(accessToken));
-    return serve.request<T[]>(queryStr);
+    return serve.request<FHIRResponse<T>>(queryStr);
   }
 
   public async read(id: string) {

--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -11,6 +11,7 @@ import { authenticateUser, updateExtraData } from '@onaio/session-reducer';
 import { store } from '@opensrp/store';
 import * as registry from '@onaio/connected-reducer-registry';
 import flushPromises from 'flush-promises';
+import { fhirR4 } from '@smile-cdr/fhirts';
 
 const {
   fetchProtectedImage,
@@ -196,13 +197,13 @@ describe('dataloaders/FHIRService', () => {
   });
 
   it('FHIRServiceClass constructor works correctly 2', async () => {
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     expect(fhir.baseURL).toEqual('https://test.fhir.org');
     expect(fhir.resourceType).toEqual('CareTeam');
   });
 
   it('buildQueryParams works', async () => {
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     expect(fhir.buildQueryParams(null)).toEqual('CareTeam');
     expect(fhir.buildQueryParams({ _count: '500', _getpagesoffset: '50' })).toEqual(
       'CareTeam/_search?_count=500&_getpagesoffset=50'
@@ -219,11 +220,13 @@ describe('dataloaders/FHIRService', () => {
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     const result = await fhir.list();
     await flushPromises();
     expect(requestMock.mock.calls).toEqual([['CareTeam']]);
     expect(result).toEqual(fixtures.careTeams);
+    // make sure every item of fhirlist returns the CareTeam
+    expect(result.entry.every((e) => e.resource.resourceType === 'CareTeam')).toBeTruthy();
   });
 
   it('FHIRServiceClass list method works with params', async () => {
@@ -236,12 +239,14 @@ describe('dataloaders/FHIRService', () => {
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     // without url params
     const result = await fhir.list({ _count: '100' });
     await flushPromises();
     expect(requestMock.mock.calls).toEqual([['CareTeam/_search?_count=100']]);
     expect(result).toEqual(fixtures.careTeams);
+    // make sure every item of fhirlist returns the CareTeam
+    expect(result.entry.every((e) => e.resource.resourceType === 'CareTeam')).toBeTruthy();
   });
 
   it('FHIRServiceClass read method works', async () => {
@@ -254,7 +259,7 @@ describe('dataloaders/FHIRService', () => {
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     const result = await fhir.read('308');
     await flushPromises();
     expect(result).toEqual(fixtures.careTeam1);
@@ -266,12 +271,12 @@ describe('dataloaders/FHIRService', () => {
     fhirMock.mockImplementation(
       jest.fn().mockImplementation(() => {
         return {
-          update: updateMock.mockResolvedValue('Success'),
+          update: updateMock.mockResolvedValue(fixtures.careTeam1),
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
-    const result = await fhir.update(fixtures.careTeam1);
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
+    const result = await fhir.update({ ...fixtures.careTeam1, name: 'New Name' });
     await flushPromises();
     expect(updateMock.mock.calls).toEqual([
       [
@@ -283,7 +288,7 @@ describe('dataloaders/FHIRService', () => {
             source: '#9bf085bac3f61473',
             versionId: '4',
           },
-          name: 'Care Team One',
+          name: 'New Name',
           participant: [
             { member: { reference: 'Practitioner/206' } },
             { member: { reference: 'Practitioner/103' } },
@@ -294,7 +299,7 @@ describe('dataloaders/FHIRService', () => {
         },
       ],
     ]);
-    expect(result).toEqual('Success');
+    expect(result).toEqual(fixtures.careTeam1);
   });
 
   it('FHIRServiceClass create method works', async () => {
@@ -303,14 +308,14 @@ describe('dataloaders/FHIRService', () => {
     fhirMock.mockImplementation(
       jest.fn().mockImplementation(() => {
         return {
-          create: createMock.mockResolvedValue('Success'),
+          create: createMock.mockResolvedValue(fixtures.careTeam1),
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     const result = await fhir.create(fixtures.careTeam1);
     await flushPromises();
-    expect(result).toEqual('Success');
+    expect(result).toEqual(fixtures.careTeam1);
   });
 
   it('FHIRServiceClass delete method works', async () => {
@@ -323,7 +328,7 @@ describe('dataloaders/FHIRService', () => {
         };
       })
     );
-    const fhir = new FHIRServiceClass('https://test.fhir.org', 'CareTeam');
+    const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     const result = await fhir.delete('308');
     await flushPromises();
     expect(result).toEqual('Success');

--- a/packages/react-utils/src/helpers/tests/fixtures.ts
+++ b/packages/react-utils/src/helpers/tests/fixtures.ts
@@ -1,3 +1,5 @@
+import { fhirR4 } from '@smile-cdr/fhirts';
+
 /* eslint-disable @typescript-eslint/camelcase */
 export const userAuthData = {
   roles: ['ROLE_OPENMRS'],
@@ -279,7 +281,7 @@ export const careTeams = {
   ],
 };
 
-export const careTeam1 = {
+export const careTeam1: fhirR4.CareTeam = {
   resourceType: 'CareTeam',
   id: '308',
   meta: {

--- a/packages/react-utils/src/helpers/utils.tsx
+++ b/packages/react-utils/src/helpers/utils.tsx
@@ -1,3 +1,4 @@
+import { Meta } from '@smile-cdr/fhirts/dist/FHIR-R4/classes/meta';
 import { Dictionary } from '@onaio/utils';
 import type { i18n as i18nInstance } from 'i18next';
 
@@ -16,3 +17,18 @@ export const loadLanguageResources = (i18n: i18nInstance | undefined, resources:
     });
   });
 };
+
+/** interface for FHIR response */
+export interface FHIRResponse<T> {
+  resourceType: string;
+  id: string;
+  meta?: Meta;
+  type: string;
+  total: number;
+  link: { relation: string; url: string }[];
+  entry: {
+    fullUrl: string;
+    resource: T;
+    search: { mode: string };
+  }[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,11 @@
   dependencies:
     type-detect "4.0.8"
 
+"@smile-cdr/fhirts@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@smile-cdr/fhirts/-/fhirts-1.2.5.tgz#e0e335b8407889d966723f212698260e7770f7c2"
+  integrity sha512-q+Q/qLswFmE3ZaGlHgO1xTibptS2gOvp3/SS8lGno3unF3Gu1+vJahan1RU/b8WL1ziUXC9Vl3fSpdsR62SqGA==
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"


### PR DESCRIPTION
This Pr adds intellisense in return .. instead of returnging generic resource we can optinally be specific and return the type we really want

like 

```
const serve = new FHIRServiceClass<Organization>(fhirbaseURL, 'Organization');
const resp: Organization = await serve.create(payload); <- update will return Organization type
```