### PR TITLE
Update commodity create/edit form view

### DIFF
--- a/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
@@ -92,11 +92,11 @@ const CommodityForm = (props: GroupFormProps) => {
       initialValues={initialValues}
     >
       <FormItem id="id" name={id} label={t('Commodity Id')}>
-        <Input disabled={true} />
+        <Input placeholder={t('(Auto generated)')} disabled={true} />
       </FormItem>
 
       <FormItem id="identifier" name={identifier} label={t('Identifier')}>
-        <Input disabled={true} />
+        <Input placeholder={t('(Auto generated)')} disabled={true} />
       </FormItem>
 
       <FormItem

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
@@ -91,11 +91,11 @@ const CommodityForm = (props: GroupFormProps) => {
       }}
       initialValues={initialValues}
     >
-      <FormItem hidden={true} id="id" name={id} label={t('Id')}>
+      <FormItem id="id" name={id} label={t('Commodity Id')}>
         <Input disabled={true} />
       </FormItem>
 
-      <FormItem hidden={true} id="identifier" name={identifier} label={t('Identifier')}>
+      <FormItem id="identifier" name={identifier} label={t('Identifier')}>
         <Input disabled={true} />
       </FormItem>
 

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/Form.tsx
@@ -73,8 +73,8 @@ const CommodityForm = (props: GroupFormProps) => {
   );
 
   const statusOptions = [
-    { label: t('Disabled'), value: false },
     { label: t('Active'), value: true },
+    { label: t('Disabled'), value: false },
   ];
 
   const unitsOfMEasureOptions = getUnitOfMeasureOptions();

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/tests/Form.test.tsx
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/tests/Form.test.tsx
@@ -153,7 +153,7 @@ describe('Health care form', () => {
 
     // status has no
     expect(wrapper.find('FormItem#active').text()).toMatchInlineSnapshot(
-      `"Select Commodity statusDisabledActiveRequired"`
+      `"Select Commodity statusActiveDisabled"`
     );
 
     // required
@@ -194,7 +194,7 @@ describe('Health care form', () => {
     // simulate active change
     wrapper
       .find('FormItem#active input')
-      .last()
+      .first()
       .simulate('change', {
         target: { checked: true },
       });
@@ -315,10 +315,10 @@ describe('Health care form', () => {
       .find('FormItem#name input')
       .simulate('change', { target: { name: 'name', value: 'Dettol Strips' } });
 
-    // simulate active check to be active
+    // simulate active check to be disabled
     wrapper
       .find('FormItem#active input')
-      .first()
+      .last()
       .simulate('change', {
         target: { checked: true },
       });

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/tests/__snapshots__/Form.test.tsx.snap
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/tests/__snapshots__/Form.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Health care form renders correctly: active field 1`] = `
 Array [
   <input
-    checked={false}
+    checked={true}
     className="ant-radio-input"
     disabled={false}
     onBlur={[Function]}
@@ -13,7 +13,7 @@ Array [
     onKeyPress={[Function]}
     onKeyUp={[Function]}
     type="radio"
-    value={false}
+    value={true}
   />,
   <input
     checked={false}
@@ -26,7 +26,7 @@ Array [
     onKeyPress={[Function]}
     onKeyUp={[Function]}
     type="radio"
-    value={true}
+    value={false}
   />,
 ]
 `;

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/utils.ts
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/utils.ts
@@ -85,7 +85,7 @@ export const validationRulesFactory = (t: TFunction) => ({
  */
 export const getGroupFormFields = (obj?: IGroup) => {
   if (!obj) {
-    return { initialObject: { code: defaultCode } } as GroupFormFields;
+    return { initialObject: { code: defaultCode }, active: true } as GroupFormFields;
   }
   const { id, name, active, identifier, type } = obj;
 
@@ -95,7 +95,7 @@ export const getGroupFormFields = (obj?: IGroup) => {
     initialObject: obj,
     id,
     identifier: get(identifierObj, '0.value'),
-    active,
+    active: active ?? true,
     name,
     type,
     unitOfMeasure: get(unitMeasureCharacteristic, 'valueCodeableConcept.text', undefined),

--- a/packages/fhir-group-management/src/components/CommodityAddEdit/utils.ts
+++ b/packages/fhir-group-management/src/components/CommodityAddEdit/utils.ts
@@ -95,7 +95,7 @@ export const getGroupFormFields = (obj?: IGroup) => {
     initialObject: obj,
     id,
     identifier: get(identifierObj, '0.value'),
-    active: active ?? true,
+    active,
     name,
     type,
     unitOfMeasure: get(unitMeasureCharacteristic, 'valueCodeableConcept.text', undefined),


### PR DESCRIPTION
closes #1084 

- Reorders radio buttons for active, Select active by default for new groups
- Show id and identifier fields