### PR TITLE
disable in lining images and scripts in react build

### DIFF
--- a/app/.env.sample
+++ b/app/.env.sample
@@ -1,5 +1,7 @@
 SKIP_PREFLIGHT_CHECK=true
 GENERATE_SOURCEMAP=false
+INLINE_RUNTIME_CHUNK=false
+IMAGE_INLINE_SIZE_LIMIT=0
 REACT_APP_WEBSITE_NAME=OpenSRP-web
 REACT_APP_DOMAIN_NAME=http://localhost:3000
 REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://keycloak-stage.smartregister.org/auth/realms/reveal-stage/protocol/openid-connect/token

--- a/app/.env.test
+++ b/app/.env.test
@@ -1,4 +1,7 @@
 SKIP_PREFLIGHT_CHECK=true
+GENERATE_SOURCEMAP=false
+INLINE_RUNTIME_CHUNK=false
+IMAGE_INLINE_SIZE_LIMIT=0
 REACT_APP_WEBSITE_NAME=OpenSRP-Web
 REACT_APP_DOMAIN_NAME=http://localhost:3000
 REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://some.keycloak.app/auth/realms/some-keycloak-realm/protocol/openid-connect/token

--- a/docs/how-to-use-docker-image.md
+++ b/docs/how-to-use-docker-image.md
@@ -70,8 +70,9 @@ Opensrp web is configured as follows:
      // others (optional override)
      SKIP_PREFLIGHT_CHECK: 'true',
      GENERATE_SOURCEMAP: 'false',
-     REACT_APP_MAIN_LOGO_SRC:
-       'https://github.com/OpenSRP/web/raw/master/app/src/assets/images/opensrp-logo-color.png',
+     INLINE_RUNTIME_CHUNK: 'false',
+     IMAGE_INLINE_SIZE_LIMIT: '0',
+     REACT_APP_MAIN_LOGO_SRC: 'https://github.com/OpenSRP/web/raw/master/app/src/assets/images/opensrp-logo-color.png',
      REACT_APP_OPENSRP_OAUTH_SCOPES: 'openid,profile',
      REACT_APP_OPENSRP_OAUTH_STATE: 'opensrp',
      REACT_APP_ENABLE_OPENSRP_OAUTH: 'true',


### PR DESCRIPTION
- closes https://github.com/opensrp/web/issues/1030
- disable inlining images and scripts in the react build - in line with csp policy recommendations
