### PR TITLE
Fhir team management ui updates.

### DIFF
--- a/packages/fhir-keycloak-user-management/src/components/UserList/ViewDetails/index.tsx
+++ b/packages/fhir-keycloak-user-management/src/components/UserList/ViewDetails/index.tsx
@@ -6,7 +6,7 @@ import {
   FHIRServiceClass,
   getResourcesFromBundle,
   loadAllResources,
-  SingleKeyNestedValue,
+  renderObjectAsKeyvalue,
 } from '@opensrp/react-utils';
 import { useQuery } from 'react-query';
 import { KeycloakService } from '@opensrp/keycloak-service';
@@ -156,27 +156,5 @@ export const ViewDetailsWrapper = (props: ViewDetailsWrapperProps) => {
         keycloakBaseUrl={keycloakBaseUrl}
       />
     </Col>
-  );
-};
-
-/**
- * Dryed out util for displaying keyValue ui for an obj
- *
- * @param obj - obj with info to be displayed
- */
-const renderObjectAsKeyvalue = (obj: Record<string, unknown>) => {
-  return (
-    <>
-      {Object.entries(obj).map(([key, value]) => {
-        const props = {
-          [key]: value,
-        };
-        return value ? (
-          <div key={key} data-testid="key-value">
-            <SingleKeyNestedValue {...props} />
-          </div>
-        ) : null;
-      })}
-    </>
   );
 };

--- a/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
@@ -104,8 +104,8 @@ const OrganizationForm = (props: OrganizationFormProps) => {
   }
 
   const statusOptions = [
-    { label: t('Inactive'), value: false },
     { label: t('active'), value: true },
+    { label: t('Inactive'), value: false },
   ];
 
   const practitionersSelectOptions = getPractitionerOptions(practitioners);
@@ -139,7 +139,7 @@ const OrganizationForm = (props: OrganizationFormProps) => {
         <Radio.Group disabled={disabled.includes(active)} options={statusOptions}></Radio.Group>
       </FormItem>
 
-      <FormItem id="type" name={type} label="Type" rules={validationRules.type}>
+      <FormItem hidden id="type" name={type} label="Type" rules={validationRules.type}>
         <Select disabled={disabled.includes(type)} options={getOrgTypeSelectOptions()}></Select>
       </FormItem>
 

--- a/packages/fhir-team-management/src/components/AddEditOrganization/tests/Form.test.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/tests/Form.test.tsx
@@ -69,6 +69,7 @@ describe('OrganizationForm', () => {
     fhirBaseUrl: 'http://test.server.org',
     practitioners: getResourcesFromBundle<IPractitioner>(allPractitioners),
     existingPractitionerRoles: [],
+    initialValues: getOrgFormFields(),
   };
 
   beforeAll(() => {
@@ -173,12 +174,10 @@ describe('OrganizationForm', () => {
     expect(wrapper.find('FormItem#alias').text()).toMatchInlineSnapshot(`"Alias"`);
 
     // status has no
-    expect(wrapper.find('FormItem#status').text()).toMatchInlineSnapshot(
-      `"StatusInactiveactiveRequired"`
-    );
+    expect(wrapper.find('FormItem#status').text()).toMatchInlineSnapshot(`"StatusactiveInactive"`);
 
     // has default value
-    expect(wrapper.find('FormItem#type').text()).toMatchInlineSnapshot(`"Type"`);
+    expect(wrapper.find('FormItem#type').text()).toMatchInlineSnapshot(`"TypeOrganizational team"`);
 
     // not required
     expect(wrapper.find('FormItem#members').text()).toMatchSnapshot(
@@ -215,7 +214,7 @@ describe('OrganizationForm', () => {
     // simulate active change
     wrapper
       .find('FormItem#status input')
-      .last()
+      .first()
       .simulate('change', {
         target: { checked: true },
       });
@@ -265,16 +264,6 @@ describe('OrganizationForm', () => {
     expect(afterFilterOptionTexts).toEqual(['Allay Allan']);
 
     fireEvent.click(document.querySelector('[title="Allay Allan"]'));
-
-    // simulate value selection for type
-    wrapper.find('input#type').simulate('mousedown');
-    document
-      .querySelectorAll('#type_list .ant-select-item ant-select-item-option')
-      .forEach((option) => {
-        expect(option).toMatchSnapshot('types option');
-      });
-
-    fireEvent.click(document.querySelector('[title="Organizational team"]'));
 
     await flushPromises();
     wrapper.update();
@@ -365,7 +354,7 @@ describe('OrganizationForm', () => {
     // simulate active check to be active
     wrapper
       .find('FormItem#status input')
-      .first()
+      .last()
       .simulate('change', {
         target: { checked: true },
       });

--- a/packages/fhir-team-management/src/components/AddEditOrganization/tests/__snapshots__/Form.test.tsx.snap
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/tests/__snapshots__/Form.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`OrganizationForm renders correctly: name label 1`] = `
 exports[`OrganizationForm renders correctly: status field 1`] = `
 Array [
   <input
-    checked={false}
+    checked={true}
     className="ant-radio-input"
     disabled={false}
     onBlur={[Function]}
@@ -155,7 +155,7 @@ Array [
     onKeyPress={[Function]}
     onKeyUp={[Function]}
     type="radio"
-    value={false}
+    value={true}
   />,
   <input
     checked={false}
@@ -168,7 +168,7 @@ Array [
     onKeyPress={[Function]}
     onKeyUp={[Function]}
     type="radio"
-    value={true}
+    value={false}
   />,
 ]
 `;

--- a/packages/fhir-team-management/src/components/AddEditOrganization/utils.ts
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/utils.ts
@@ -62,7 +62,7 @@ export const getOrgFormFields = (
   assignedPractitioners: IPractitionerRole[] = []
 ): OrganizationFormFields => {
   if (!org) {
-    return {};
+    return { type: 'team', active: true };
   }
   const { id, name, alias, active, identifier, type } = org;
 

--- a/packages/fhir-team-management/src/components/OrganizationList/ListView/index.tsx
+++ b/packages/fhir-team-management/src/components/OrganizationList/ListView/index.tsx
@@ -63,11 +63,6 @@ export const OrganizationList = (props: OrganizationListProps) => {
       key: 'name' as const,
     },
     {
-      title: t('Type'),
-      dataIndex: 'type' as const,
-      key: 'type' as const,
-    },
-    {
       title: t('Actions'),
       width: '10%',
       // eslint-disable-next-line react/display-name

--- a/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/__snapshots__/index.test.tsx.snap
@@ -20,12 +20,6 @@ exports[`renders correctly when listing organizations: Search 1 page 1 1`] = `
 exports[`renders correctly when listing organizations: Search 1 page 1 2`] = `
 <td
   class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: Search 1 page 1 3`] = `
-<td
-  class="ant-table-cell"
 >
   <span
     class="d-flex align-items-center"
@@ -71,6 +65,112 @@ exports[`renders correctly when listing organizations: Search 1 page 1 3`] = `
 </td>
 `;
 
+exports[`renders correctly when listing organizations: single key value pairs detail section 1`] = `
+<div
+  class="singleKeyValue-pair"
+>
+  <dt
+    class="singleKeyValue-pair__label"
+  >
+    <span
+      class="ant-typography ant-typography-secondary"
+    >
+      Team id
+    </span>
+  </dt>
+  <dd
+    class="singleKeyValue-pair__value"
+  >
+    <span
+      class="ant-typography"
+    >
+      205
+    </span>
+  </dd>
+</div>
+`;
+
+exports[`renders correctly when listing organizations: single key value pairs detail section 2`] = `
+<div
+  class="singleKeyValue-pair"
+>
+  <dt
+    class="singleKeyValue-pair__label"
+  >
+    <span
+      class="ant-typography ant-typography-secondary"
+    >
+      Team identifier
+    </span>
+  </dt>
+  <dd
+    class="singleKeyValue-pair__value"
+  >
+    <span
+      class="ant-typography"
+    >
+      205
+    </span>
+  </dd>
+</div>
+`;
+
+exports[`renders correctly when listing organizations: single key value pairs detail section 3`] = `
+<div
+  class="singleKeyValue-pair"
+>
+  <dt
+    class="singleKeyValue-pair__label"
+  >
+    <span
+      class="ant-typography ant-typography-secondary"
+    >
+      Team status
+    </span>
+  </dt>
+  <dd
+    class="singleKeyValue-pair__value"
+  >
+    <span
+      class="ant-typography"
+    >
+      Active
+    </span>
+  </dd>
+</div>
+`;
+
+exports[`renders correctly when listing organizations: single key value pairs detail section 4`] = `
+<div
+  class="singleKeyValue-pair"
+>
+  <dt
+    class="singleKeyValue-pair__label"
+  >
+    <span
+      class="ant-typography ant-typography-secondary"
+    >
+      Team practitioners
+    </span>
+  </dt>
+  <dd
+    class="singleKeyValue-pair__value"
+  >
+    <span
+      class="ant-typography"
+    >
+      <ul
+        id="practitioner-teams"
+      >
+        <li>
+          Allay Allan
+        </li>
+      </ul>
+    </span>
+  </dd>
+</div>
+`;
+
 exports[`renders correctly when listing organizations: table row 1 page 1 1`] = `
 <td
   class="ant-table-cell"
@@ -80,12 +180,6 @@ exports[`renders correctly when listing organizations: table row 1 page 1 1`] = 
 `;
 
 exports[`renders correctly when listing organizations: table row 1 page 1 2`] = `
-<td
-  class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 1 page 1 3`] = `
 <td
   class="ant-table-cell"
 >
@@ -144,12 +238,6 @@ exports[`renders correctly when listing organizations: table row 1 page 2 1`] = 
 exports[`renders correctly when listing organizations: table row 1 page 2 2`] = `
 <td
   class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 1 page 2 3`] = `
-<td
-  class="ant-table-cell"
 >
   <span
     class="d-flex align-items-center"
@@ -204,12 +292,6 @@ exports[`renders correctly when listing organizations: table row 2 page 1 1`] = 
 `;
 
 exports[`renders correctly when listing organizations: table row 2 page 1 2`] = `
-<td
-  class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 2 page 1 3`] = `
 <td
   class="ant-table-cell"
 >
@@ -268,12 +350,6 @@ exports[`renders correctly when listing organizations: table row 2 page 2 1`] = 
 exports[`renders correctly when listing organizations: table row 2 page 2 2`] = `
 <td
   class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 2 page 2 3`] = `
-<td
-  class="ant-table-cell"
 >
   <span
     class="d-flex align-items-center"
@@ -330,12 +406,6 @@ exports[`renders correctly when listing organizations: table row 3 page 1 1`] = 
 exports[`renders correctly when listing organizations: table row 3 page 1 2`] = `
 <td
   class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 3 page 1 3`] = `
-<td
-  class="ant-table-cell"
 >
   <span
     class="d-flex align-items-center"
@@ -390,12 +460,6 @@ exports[`renders correctly when listing organizations: table row 3 page 2 1`] = 
 `;
 
 exports[`renders correctly when listing organizations: table row 3 page 2 2`] = `
-<td
-  class="ant-table-cell"
-/>
-`;
-
-exports[`renders correctly when listing organizations: table row 3 page 2 3`] = `
 <td
   class="ant-table-cell"
 >

--- a/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/fixtures.tsx
+++ b/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/fixtures.tsx
@@ -223,3 +223,88 @@ export const organizationSearchPage1 = {
     },
   ],
 };
+
+export const assignedPractitionerRole = {
+  resourceType: 'Bundle',
+  id: 'c1ea2f2d-b254-4b2c-accd-798b7a75eb8f',
+  meta: {
+    lastUpdated: '2022-09-21T08:46:13.449+00:00',
+  },
+  type: 'searchset',
+  total: 1,
+  link: [
+    {
+      relation: 'self',
+      url: 'https://fhir.labs.smartregister.org:443/fhir/PractitionerRole/_search?_count=1&_format=json&_include=PractitionerRole%3Apractitioner&organization=145365',
+    },
+  ],
+  entry: [
+    {
+      fullUrl: 'https://fhir.labs.smartregister.org:443/fhir/PractitionerRole/145366',
+      resource: {
+        resourceType: 'PractitionerRole',
+        id: '145366',
+        meta: {
+          versionId: '1',
+          lastUpdated: '2022-09-21T08:04:22.476+00:00',
+          source: '#32215d034f3576a1',
+        },
+        identifier: [
+          {
+            use: 'official',
+            value: '9d82691a-c33c-467f-a8ec-367e1cd823aa',
+          },
+        ],
+        active: true,
+        practitioner: {
+          reference: 'Practitioner/206',
+          display: 'Allay Allan',
+        },
+        organization: {
+          reference: 'Organization/145365',
+          display: 'peter practitioner sep21',
+        },
+      },
+      search: {
+        mode: 'match',
+      },
+    },
+    {
+      fullUrl: 'https://fhir.labs.smartregister.org:443/fhir/Practitioner/206',
+      resource: {
+        resourceType: 'Practitioner',
+        id: '206',
+        meta: {
+          versionId: '2',
+          lastUpdated: '2021-09-14T07:37:31.213+00:00',
+          source: '#74cc383a67268f33',
+        },
+        identifier: [
+          {
+            use: 'official',
+            value: 'c1d36d9a-b771-410b-959e-af2c04d132a2',
+          },
+          {
+            use: 'secondary',
+          },
+        ],
+        active: false,
+        name: [
+          {
+            use: 'official',
+            family: 'Allan',
+            given: ['Allay'],
+          },
+        ],
+        telecom: [
+          {
+            system: 'email',
+          },
+        ],
+      },
+      search: {
+        mode: 'include',
+      },
+    },
+  ],
+};

--- a/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/index.test.tsx
+++ b/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/index.test.tsx
@@ -191,12 +191,6 @@ test('renders correctly when listing organizations', async () => {
     })
     .reply(200, assignedPractitionerRole);
 
-  // see details in viewDetails
-
-  document.querySelectorAll('.singleKeyValue-pair').forEach((pair) => {
-    expect(pair).toMatchSnapshot('single key value pairs detail section');
-  });
-
   // target the initial row view details
   const dropdown = document.querySelector('tbody tr:nth-child(1) [data-testid="action-dropdown"]');
   fireEvent.click(dropdown);
@@ -213,6 +207,11 @@ test('renders correctly when listing organizations', async () => {
   expect(history.location.pathname).toEqual('/admin/teams/205');
 
   await waitForElementToBeRemoved(document.querySelector('.ant-spin'));
+
+  // see details in viewDetails
+  document.querySelectorAll('.singleKeyValue-pair').forEach((pair) => {
+    expect(pair).toMatchSnapshot('single key value pairs detail section');
+  });
 
   // close view details
   const closeButton = document.querySelector('[data-testid="close-button"]');

--- a/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/index.test.tsx
+++ b/packages/fhir-team-management/src/components/OrganizationList/ListView/tests/index.test.tsx
@@ -9,8 +9,17 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import nock from 'nock';
 import { waitForElementToBeRemoved } from '@testing-library/dom';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { organizationResourceType, ORGANIZATION_LIST_URL } from '../../../../constants';
-import { organizationSearchPage1, organizationsPage1, organizationsPage2 } from './fixtures';
+import {
+  organizationResourceType,
+  ORGANIZATION_LIST_URL,
+  practitionerRoleResourceType,
+} from '../../../../constants';
+import {
+  assignedPractitionerRole,
+  organizationSearchPage1,
+  organizationsPage1,
+  organizationsPage2,
+} from './fixtures';
 import userEvents from '@testing-library/user-event';
 
 jest.mock('fhirclient', () => {
@@ -174,6 +183,19 @@ test('renders correctly when listing organizations', async () => {
   nock(props.fhirBaseURL)
     .get(`/${organizationResourceType}/205`)
     .reply(200, organizationSearchPage1.entry[0].resource);
+  nock(props.fhirBaseURL)
+    .get(`/${practitionerRoleResourceType}/_search`)
+    .query({
+      _include: 'PractitionerRole:practitioner',
+      organization: `205`,
+    })
+    .reply(200, assignedPractitionerRole);
+
+  // see details in viewDetails
+
+  document.querySelectorAll('.singleKeyValue-pair').forEach((pair) => {
+    expect(pair).toMatchSnapshot('single key value pairs detail section');
+  });
 
   // target the initial row view details
   const dropdown = document.querySelector('tbody tr:nth-child(1) [data-testid="action-dropdown"]');

--- a/packages/react-utils/src/components/KeyValuePairs/index.tsx
+++ b/packages/react-utils/src/components/KeyValuePairs/index.tsx
@@ -44,3 +44,25 @@ export const SingleKeyNestedValue = (props: KeyValuePairs) => {
     </dl>
   );
 };
+
+/**
+ * Dryed out util for displaying keyValue ui for an obj
+ *
+ * @param obj - obj with info to be displayed
+ */
+export const renderObjectAsKeyvalue = (obj: Record<string, unknown>) => {
+  return (
+    <>
+      {Object.entries(obj).map(([key, value]) => {
+        const props = {
+          [key]: value,
+        };
+        return value ? (
+          <div key={key} data-testid="key-value">
+            <SingleKeyNestedValue {...props} />
+          </div>
+        ) : null;
+      })}
+    </>
+  );
+};


### PR DESCRIPTION
closes #1080 

- remove type column in organization list
- Show practitioners assigned to an organization in the organization detail view
- hide type field in org form
- Reorder org form active radio groups and default to true when creating a new organization