### PR TITLE
Load organization for edit only after assigned practtioners are fully loaded

### DIFF
--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -74,7 +74,8 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
 
   if (
     (!organization.isIdle && organization.isLoading) ||
-    (!practitioners.isIdle && practitioners.isLoading)
+    (!practitioners.isIdle && practitioners.isLoading) ||
+    (!assignedPractitioners.isIdle && assignedPractitioners.isLoading)
   ) {
     return <Spin size="large" className="custom-spinner"></Spin>;
   }

--- a/packages/fhir-team-management/src/components/AddEditOrganization/tests/index.test.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/tests/index.test.tsx
@@ -125,6 +125,8 @@ test('renders correctly for edit locations', async () => {
 
   await waitForElementToBeRemoved(document.querySelector('.ant-spin'));
 
+  expect(nock.pendingMocks()).toEqual([]);
+
   expect(document.querySelector('title')).toMatchInlineSnapshot(`
     <title>
       Edit team | OpenSRP web Test Organisation


### PR DESCRIPTION
Load organization for edit only after assigned practtioners are fully loaded
- close #1158