### PR TITLE
Fix active sidebar bug

### DIFF
--- a/app/src/containers/pages/Home/tests/__snapshots__/Home.test.tsx.snap
+++ b/app/src/containers/pages/Home/tests/__snapshots__/Home.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`containers/pages/Home renders Home correctly & changes Title of page 2:
 exports[`containers/pages/Home renders Home correctly & changes Title of page 2: Team Management 1`] = `
 <a
   class="admin-link"
-  href=""
+  href="/admin/teams"
 >
   <button
     class="ant-btn ant-btn-default btn-links"

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -103,7 +103,7 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
     {
       otherProps: { icon: <IdcardOutlined /> },
       title: t('Card Support'),
-      key: 'card-support',
+      key: 'download-client-data',
       url: URL_DOWNLOAD_CLIENT_DATA,
       isHomePageLink: true,
       enabled:
@@ -151,7 +151,7 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
       children: [
         {
           title: t('User Management'),
-          key: 'user-management',
+          key: 'users',
           isHomePageLink: true,
           url: URL_USER,
           enabled:
@@ -167,7 +167,7 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
         },
         {
           title: t('Location Management'),
-          key: 'location-management',
+          key: 'location-units',
           isHomePageLink: true,
           url: URL_LOCATION_UNIT,
           enabled:
@@ -176,7 +176,7 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
             activeRoles.LOCATIONS &&
             isAuthorized(roles, activeRoles.LOCATIONS.split(',')),
           children: [
-            { title: t('Location Units'), url: URL_LOCATION_UNIT, key: 'location-unit' },
+            { title: t('Location Units'), url: URL_LOCATION_UNIT, key: 'location-units' },
             {
               enabled: !ENABLE_FHIR_LOCATIONS,
               title: t('Location Unit Group'),
@@ -209,15 +209,16 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
         },
         {
           title: t('Team Management'),
-          key: 'team-management',
+          key: 'teams',
           isHomePageLink: true,
+          url: URL_TEAMS,
           enabled:
             COMPOSITE_ENABLE_TEAM_MANAGEMENT &&
             roles &&
             activeRoles.TEAMS &&
             isAuthorized(roles, activeRoles.TEAMS.split(',')),
           children: [
-            { title: t('Teams'), url: URL_TEAMS, key: 'TEAMS' },
+            { title: t('Teams'), url: URL_TEAMS, key: 'teams' },
             {
               title: t('Team Assignment'),
               url: URL_TEAM_ASSIGNMENT,
@@ -272,7 +273,7 @@ export function getRoutes(roles: string[], t: TFunction): Route[] {
         },
         {
           title: t('Form Configuration'),
-          key: 'form-config',
+          key: 'form-config-releases',
           isHomePageLink: true,
           url: URL_MANIFEST_RELEASE_LIST,
           enabled:

--- a/app/src/routes/tests/index.test.tsx
+++ b/app/src/routes/tests/index.test.tsx
@@ -171,7 +171,7 @@ describe('routes', () => {
           },
         ],
         enabled: true,
-        key: 'card-support',
+        key: 'download-client-data',
         otherProps: {
           icon: <IdcardOutlined />,
         },
@@ -218,13 +218,13 @@ describe('routes', () => {
               },
             ],
             enabled: true,
-            key: 'user-management',
+            key: 'users',
             title: 'User Management',
           },
           {
             children: [
               {
-                key: 'location-unit',
+                key: 'location-units',
                 title: 'Location Units',
                 url: '/admin/location/unit',
               },
@@ -235,7 +235,7 @@ describe('routes', () => {
               },
             ],
             enabled: true,
-            key: 'location-management',
+            key: 'location-units',
             title: 'Location Management',
           },
           {
@@ -247,7 +247,7 @@ describe('routes', () => {
           {
             children: [
               {
-                key: 'TEAMS',
+                key: 'teams',
                 title: 'Teams',
                 url: '/admin/teams',
               },
@@ -259,7 +259,7 @@ describe('routes', () => {
               },
             ],
             enabled: true,
-            key: 'team-management',
+            key: 'teams',
             title: 'Team Management',
           },
           { enabled: true, key: 'fhir-quest', title: 'Questionnaire Management', url: '/quest' },
@@ -282,7 +282,7 @@ describe('routes', () => {
               },
             ],
             enabled: true,
-            key: 'form-config',
+            key: 'form-config-releases',
             title: 'Form Configuration',
           },
           {
@@ -327,8 +327,8 @@ describe('routes', () => {
       (t: string) => t
     );
     const parentKeys = routes.flatMap((x) => x.children).map((x) => x.key);
-    expect(parentKeys).toContain('team-management');
-    expect(parentKeys).toContain('user-management');
-    expect(parentKeys).toContain('location-management');
+    expect(parentKeys).toContain('teams');
+    expect(parentKeys).toContain('users');
+    expect(parentKeys).toContain('location-units');
   });
 });


### PR DESCRIPTION
Team management link in landing page now navigates to the team list view.
All menu items on the sidebar highlight when active.