### PR TITLE
Inspect long running test in opensrp-plans

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -3,3 +3,7 @@
 
 
 yarn-path ".yarn/releases/yarn-1.18.0.cjs"
+
+# yarn install timing out on github ci - increase timeout to 5 mins
+# https://github.com/yarnpkg/yarn/issues/5540#issuecomment-374069461
+network-timeout 300000

--- a/packages/opensrp-plans/src/containers/NewPlan/tests/index.test.tsx
+++ b/packages/opensrp-plans/src/containers/NewPlan/tests/index.test.tsx
@@ -6,7 +6,7 @@ import { Router } from 'react-router';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 import { Helmet } from 'react-helmet';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 import { PlanFormFieldsKeys } from '@opensrp/plan-form';
 import { DRAFT_PLANS_LIST_VIEW_URL } from '../../../constants';
@@ -51,6 +51,8 @@ describe('Create Plan Page', () => {
     expect((wrapper.find('Router').props() as any).history.location.pathname).toEqual(
       DRAFT_PLANS_LIST_VIEW_URL
     );
+
+    wrapper.unmount();
   });
 
   it('planForm gets configured', async () => {
@@ -110,5 +112,7 @@ describe('Create Plan Page', () => {
 
     // date is  hidden by default
     expect(wrapper.find('FormItem#description').props().hidden).toBeFalsy();
+
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
Not sure why yet, but using react testing library act fixed the issue in these tests.