### PR TITLE
Pre-poulate application id field

### DIFF
--- a/packages/keycloak-user-management/src/components/CreateEditUser/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/keycloak-user-management/src/components/CreateEditUser/tests/__snapshots__/index.test.tsx.snap
@@ -12,6 +12,7 @@ Object {
           "active": true,
           "contact": undefined,
           "enabled": true,
+          "fhirCoreAppId": undefined,
           "firstName": "",
           "id": "",
           "lastName": "",

--- a/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
@@ -276,6 +276,7 @@ export const defaultUserFormInitialValues: FormFields = {
   practitioner: undefined,
   contact: undefined,
   enabled: true,
+  fhirCoreAppId: undefined,
 };
 
 UserForm.defaultProps = {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -272,7 +272,7 @@ export const getFormValues = (
     userGroups: userGroups?.map((tag) => tag.id),
     keycloakUser,
     practitionerRole,
-    fhirCoreAppId,
+    fhirCoreAppId: fhirCoreAppId?.[0],
   };
 };
 

--- a/packages/keycloak-user-management/src/ducks/user.ts
+++ b/packages/keycloak-user-management/src/ducks/user.ts
@@ -40,7 +40,7 @@ export interface UserAction {
 export interface UserAttributes {
   // while these may be adhoc and arbitrary it carries with it serious back and cross compatibility issues, these should not be modified lightly
   contact?: string[];
-  fhir_core_app_id?: string;
+  fhir_core_app_id?: string[];
 }
 
 /** Interface for user json object */


### PR DESCRIPTION
The application id is returned as a string array, so this changes the user attribute to a string array then access the value.
closes #1229