### PR TITLE
Add intuitive messages for failed requests

### DIFF
--- a/app/src/components/Logout/index.tsx
+++ b/app/src/components/Logout/index.tsx
@@ -33,7 +33,7 @@ export const CustomLogout: React.FC = (): JSX.Element => {
   const history = useHistory();
   logout(payload, KEYCLOAK_LOGOUT_URL, redirectUri, OPENSRP_LOGOUT_URL, idTokenHint).catch(
     (_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem logging out. Please try again.'));
       history.push('/');
     }
   );

--- a/app/src/components/Logout/tests/index.test.tsx
+++ b/app/src/components/Logout/tests/index.test.tsx
@@ -94,6 +94,8 @@ describe('components/Logout', () => {
     await act(async () => {
       await flushPromises();
     });
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem logging out. Please try again.'
+    );
   });
 });

--- a/packages/card-support/src/components/DownloadClientData/index.tsx
+++ b/packages/card-support/src/components/DownloadClientData/index.tsx
@@ -132,7 +132,10 @@ const DownloadClientData: React.FC<DownloadClientDataProps> = (props: DownloadCl
     {
       // start fetching when userLocSettings hook succeeds
       enabled: userLocSettings.isSuccess && userLocSettings.data.uuid.length > 0,
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () =>
+        sendErrorNotification(
+          t('There was a problem fetching the location hierachy for the assigned location')
+        ),
       onSuccess: (res: RawOpenSRPHierarchy) => {
         const hierarchy = generateJurisdictionTree(res);
         dispatch(fetchAllHierarchiesActionCreator([hierarchy.model]));
@@ -175,7 +178,7 @@ const DownloadClientData: React.FC<DownloadClientDataProps> = (props: DownloadCl
               locationHierarchies,
               setSubmitting,
               t
-            ).catch(() => sendErrorNotification(t('An error occurred')));
+            ).catch(() => sendErrorNotification(t('There was a problem submitting the form')));
           }}
         >
           <Form.Item name="clientLocation" label={t('Client Location')}>

--- a/packages/card-support/src/components/DownloadClientData/tests/index.test.tsx
+++ b/packages/card-support/src/components/DownloadClientData/tests/index.test.tsx
@@ -465,6 +465,8 @@ describe('components/DownloadClientData', () => {
       wrapper.update();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching the location hierachy for the assigned location'
+    );
   });
 });

--- a/packages/card-support/src/components/DownloadClientData/tests/utils.test.tsx
+++ b/packages/card-support/src/components/DownloadClientData/tests/utils.test.tsx
@@ -237,7 +237,9 @@ describe('components/DownloadClientData/utils/submitForm', () => {
     ]);
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);
     expect(papaparseMock).not.toHaveBeenCalled();
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem submitting download client data form'
+    );
   });
 
   it('handles error if submit form fails', async () => {
@@ -290,7 +292,9 @@ describe('components/DownloadClientData/utils/submitForm', () => {
     ]);
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);
     expect(papaparseMock).not.toHaveBeenCalled();
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem submitting download client data form'
+    );
   });
 
   it('calls API correctly if card status is empty', async () => {

--- a/packages/card-support/src/components/DownloadClientData/tests/utils.test.tsx
+++ b/packages/card-support/src/components/DownloadClientData/tests/utils.test.tsx
@@ -238,7 +238,7 @@ describe('components/DownloadClientData/utils/submitForm', () => {
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);
     expect(papaparseMock).not.toHaveBeenCalled();
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There was a problem submitting download client data form'
+      'There was a problem submitting the data form'
     );
   });
 
@@ -293,7 +293,7 @@ describe('components/DownloadClientData/utils/submitForm', () => {
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);
     expect(papaparseMock).not.toHaveBeenCalled();
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There was a problem submitting download client data form'
+      'There was a problem submitting the data form'
     );
   });
 

--- a/packages/card-support/src/components/DownloadClientData/utils.tsx
+++ b/packages/card-support/src/components/DownloadClientData/utils.tsx
@@ -94,7 +94,7 @@ export const submitForm = async (
         flatNestedLocationIdsWithClientLocationId.join(',');
       return stringifiedFlatNestedLocationIdsWithClientLocationId;
     } catch (_) {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t("There was a problem fetching nested location Id's"));
       return '';
     }
   };
@@ -164,7 +164,7 @@ export const submitForm = async (
     })
     .catch((_: Error) => {
       setSubmitting(false);
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem submitting download client data form'));
     });
 };
 

--- a/packages/card-support/src/components/DownloadClientData/utils.tsx
+++ b/packages/card-support/src/components/DownloadClientData/utils.tsx
@@ -164,7 +164,7 @@ export const submitForm = async (
     })
     .catch((_: Error) => {
       setSubmitting(false);
-      sendErrorNotification(t('There was a problem submitting download client data form'));
+      sendErrorNotification(t('There was a problem submitting the data form'));
     });
 };
 

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/Form.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/Form.tsx
@@ -72,9 +72,9 @@ const CareTeamForm: React.FC<CareTeamFormProps> = (props: CareTeamFormProps) => 
             submitForm(values, initialValues, fhirBaseURL, organizations, practitioners, t)
               .catch(() => {
                 if (initialValues.id) {
-                  sendErrorNotification(t('There was a problem updating Care Team'));
+                  sendErrorNotification(t('There was a problem updating the Care Team'));
                 } else {
-                  sendErrorNotification(t('There was a problem creating Care Team'));
+                  sendErrorNotification(t('There was a problem creating the Care Team'));
                 }
               })
               .finally(() => setIsSubmitting(false));

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/Form.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/Form.tsx
@@ -70,7 +70,13 @@ const CareTeamForm: React.FC<CareTeamFormProps> = (props: CareTeamFormProps) => 
           onFinish={(values: FormFields) => {
             setIsSubmitting(true);
             submitForm(values, initialValues, fhirBaseURL, organizations, practitioners, t)
-              .catch(() => sendErrorNotification(t('An error occurred')))
+              .catch(() => {
+                if (initialValues.id) {
+                  sendErrorNotification(t('There was a problem updating Care Team'));
+                } else {
+                  sendErrorNotification(t('There was a problem creating Care Team'));
+                }
+              })
               .finally(() => setIsSubmitting(false));
           }}
         >

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/index.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/index.tsx
@@ -52,7 +52,7 @@ const CreateEditCareTeam: React.FC<CreateEditCareTeamProps> = (props: CreateEdit
     [FHIR_CARE_TEAM, careTeamId],
     async () => await new FHIRServiceClass(fhirBaseURL, FHIR_CARE_TEAM).read(careTeamId as string),
     {
-      onError: () => sendErrorNotification(t('There was a problem fetching Care Team')),
+      onError: () => sendErrorNotification(t('There was a problem fetching the Care Team')),
       select: (res) => res,
       enabled: !!careTeamId,
       cacheTime: 0,

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/index.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/index.tsx
@@ -52,7 +52,7 @@ const CreateEditCareTeam: React.FC<CreateEditCareTeamProps> = (props: CreateEdit
     [FHIR_CARE_TEAM, careTeamId],
     async () => await new FHIRServiceClass(fhirBaseURL, FHIR_CARE_TEAM).read(careTeamId as string),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Care Team')),
       select: (res) => res,
       enabled: !!careTeamId,
       cacheTime: 0,
@@ -64,7 +64,7 @@ const CreateEditCareTeam: React.FC<CreateEditCareTeamProps> = (props: CreateEdit
     organizationResourceType,
     async () => loadAllResources(fhirBaseURL, organizationResourceType),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching organizations')),
       select: (res) => getResourcesFromBundle<IOrganization>(res),
     }
   );
@@ -73,7 +73,7 @@ const CreateEditCareTeam: React.FC<CreateEditCareTeamProps> = (props: CreateEdit
     FHIR_PRACTITIONERS,
     async () => loadAllResources(fhirBaseURL, practitionerResourceType, { active: true }),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching practitioners')),
       select: (res) => getResourcesFromBundle<IPractitioner>(res),
     }
   );

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/utils.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/utils.tsx
@@ -154,7 +154,7 @@ export const submitForm = async (
     // TODO - possible place to use translation plurals
     .then(() => sendSuccessNotification(successNotificationMessage))
     .catch(() => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching Care Team'));
     })
     .finally(() => history.push(URL_CARE_TEAM));
 };

--- a/packages/fhir-care-team/src/components/CreateEditCareTeam/utils.tsx
+++ b/packages/fhir-care-team/src/components/CreateEditCareTeam/utils.tsx
@@ -154,7 +154,7 @@ export const submitForm = async (
     // TODO - possible place to use translation plurals
     .then(() => sendSuccessNotification(successNotificationMessage))
     .catch(() => {
-      sendErrorNotification(t('There was a problem fetching Care Team'));
+      sendErrorNotification(t('There was a problem fetching the Care Team'));
     })
     .finally(() => history.push(URL_CARE_TEAM));
 };

--- a/packages/fhir-care-team/src/components/ListView/index.tsx
+++ b/packages/fhir-care-team/src/components/ListView/index.tsx
@@ -50,7 +50,7 @@ export const deleteCareTeam = async (
   return serve
     .delete(id)
     .then(() => sendSuccessNotification(t('Successfully Deleted Care Team')))
-    .catch(() => sendErrorNotification(t('An error occurred')));
+    .catch(() => sendErrorNotification(t('There was a problem deleting the Care Team')));
 };
 
 /**

--- a/packages/fhir-care-team/src/components/ListView/tests/index.test.tsx
+++ b/packages/fhir-care-team/src/components/ListView/tests/index.test.tsx
@@ -146,7 +146,9 @@ describe('Care Teams list view', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorsMock.mock.calls).toEqual([['An error occurred']]);
+    expect(notificationErrorsMock.mock.calls).toEqual([
+      ['There was a problem deleting the Care Team'],
+    ]);
   });
 });
 

--- a/packages/fhir-client/src/components/PatientDetails/index.tsx
+++ b/packages/fhir-client/src/components/PatientDetails/index.tsx
@@ -72,7 +72,7 @@ const PatientDetails: React.FC<PatientDetailPropTypes> = (props: PatientDetailPr
   }
 
   if (error) {
-    return <BrokenPage errorMessage={t('An error occurred')} />;
+    return <BrokenPage errorMessage={t('There was a problem fetching the patient')} />;
   }
 
   const resourceTypeMap: ResourceTypeMap = {};

--- a/packages/fhir-client/src/components/PatientDetails/tests/index.test.tsx
+++ b/packages/fhir-client/src/components/PatientDetails/tests/index.test.tsx
@@ -176,6 +176,6 @@ describe('Patients list view', () => {
 
     await waitForElementToBeRemoved(document.querySelector('.ant-spin'));
 
-    expect(screen.getByText(/An error occurred/)).toBeInTheDocument();
+    expect(screen.getByText(/There was a problem fetching the patient/)).toBeInTheDocument();
   });
 });

--- a/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
@@ -34,7 +34,7 @@ import {
   OrganizationFormFields,
   validationRulesFactory,
 } from './utils';
-import { formItemLayout, tailLayout } from '@opensrp/react-utils';
+import { formItemLayout, getErrorMessages, tailLayout } from '@opensrp/react-utils';
 import { PractToOrgAssignmentStrategy } from '@opensrp/pkg-config';
 
 const { Item: FormItem } = Form;
@@ -100,7 +100,17 @@ const OrganizationForm = (props: OrganizationFormProps) => {
     },
     {
       onError: (err: Error) => {
-        sendErrorNotification(err.message);
+        const getObj: number = err.message.indexOf('{');
+        const sliceObj: string = err.message.slice(getObj);
+
+        const parsed = JSON.parse(sliceObj);
+
+        const errMsg = getErrorMessages(parsed)
+
+        errMsg.forEach((error: string) => {
+          console.log({ error })
+          sendErrorNotification(t(error))
+        })
       },
       onSuccess: () => {
         queryClient.invalidateQueries([organizationResourceType]).catch(() => {

--- a/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/Form.tsx
@@ -34,7 +34,7 @@ import {
   OrganizationFormFields,
   validationRulesFactory,
 } from './utils';
-import { formItemLayout, getErrorMessages, tailLayout } from '@opensrp/react-utils';
+import { formItemLayout, tailLayout } from '@opensrp/react-utils';
 import { PractToOrgAssignmentStrategy } from '@opensrp/pkg-config';
 
 const { Item: FormItem } = Form;
@@ -99,18 +99,8 @@ const OrganizationForm = (props: OrganizationFormProps) => {
       });
     },
     {
-      onError: (err: Error) => {
-        const getObj: number = err.message.indexOf('{');
-        const sliceObj: string = err.message.slice(getObj);
-
-        const parsed = JSON.parse(sliceObj);
-
-        const errMsg = getErrorMessages(parsed)
-
-        errMsg.forEach((error: string) => {
-          console.log({ error })
-          sendErrorNotification(t(error))
-        })
+      onError: () => {
+        sendErrorNotification(t('There was a problem updating organization'));
       },
       onSuccess: () => {
         queryClient.invalidateQueries([organizationResourceType]).catch(() => {

--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -55,7 +55,10 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     () => loadAllResources(fhirBaseUrl, practitionerResourceType),
     {
       select: (res) => getResourcesFromBundle(res) as IPractitionerRole[],
-      onError: () => sendErrorNotification(t('An Error occurred')),
+      onError: (err: Error) => {
+        // sendErrorNotification(t('An Error occurred'))
+        console.log(err.message)
+      },
     }
   );
 
@@ -64,7 +67,10 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     [practitionerResourceType, organizationResourceType, orgId],
     () => loadAllResources(fhirBaseUrl, practitionerRoleResourceType),
     {
-      onError: () => sendErrorNotification(t('An Error occurred')),
+      onError: (err: Error) => {
+        // sendErrorNotification(t('An Error occurred'))
+        console.log(err)
+      },
       select: (res) => {
         return getResourcesFromBundle(res) as IPractitionerRole[];
       },

--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -55,10 +55,7 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     () => loadAllResources(fhirBaseUrl, practitionerResourceType),
     {
       select: (res) => getResourcesFromBundle(res) as IPractitionerRole[],
-      onError: (err: Error) => {
-        // sendErrorNotification(t('An Error occurred'))
-        console.log(err.message)
-      },
+      onError: () => sendErrorNotification(t('There was a problem fetching practitioners')),
     }
   );
 
@@ -67,10 +64,8 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     [practitionerResourceType, organizationResourceType, orgId],
     () => loadAllResources(fhirBaseUrl, practitionerRoleResourceType),
     {
-      onError: (err: Error) => {
-        // sendErrorNotification(t('An Error occurred'))
-        console.log(err)
-      },
+      onError: () =>
+        sendErrorNotification(t('There was a problem fetching assigned practitioners')),
       select: (res) => {
         return getResourcesFromBundle(res) as IPractitionerRole[];
       },

--- a/packages/fhir-team-management/src/components/AddEditOrganization/tests/Form.test.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/tests/Form.test.tsx
@@ -410,11 +410,7 @@ describe('OrganizationForm', () => {
 
     await waitFor(() => {
       expect(successNoticeMock.mock.calls).toEqual([['Organization updated successfully']]);
-      expect(errorNoticeMock.mock.calls).toEqual([
-        [
-          'request to http://test.server.org/PractitionerRole/9b782015-8392-4847-b48c-50c11638656b failed, reason: Failed operation outcome',
-        ],
-      ]);
+      expect(errorNoticeMock.mock.calls).toEqual([['There was a problem updating organization']]);
     });
 
     expect(nock.isDone()).toBeTruthy();

--- a/packages/form-config-antd/src/components/DraftFileList/TableActions/index.tsx
+++ b/packages/form-config-antd/src/components/DraftFileList/TableActions/index.tsx
@@ -50,7 +50,7 @@ const TableActions = (props: TableActionsProps): JSX.Element => {
             isJsonValidator,
             customFetchOptions
           ).catch((_: Error) => {
-            sendErrorNotification(t('An error occurred'));
+            sendErrorNotification(t('There was a problem downloading this file'));
           })
         }
       >

--- a/packages/form-config-antd/src/components/DraftFileList/index.tsx
+++ b/packages/form-config-antd/src/components/DraftFileList/index.tsx
@@ -165,7 +165,9 @@ const DrafFileList = (props: DraftFileListProps): JSX.Element => {
                   OPENSRP_MANIFEST_ENDPOINT,
                   dispatch,
                   customFetchOptions
-                ).catch(() => sendErrorNotification(t('There was a problem when making release')))
+                ).catch(() =>
+                  sendErrorNotification(t('An error occurred while uploading the file'))
+                )
               }
             >
               {t('Make Release')}

--- a/packages/form-config-antd/src/components/DraftFileList/index.tsx
+++ b/packages/form-config-antd/src/components/DraftFileList/index.tsx
@@ -165,7 +165,7 @@ const DrafFileList = (props: DraftFileListProps): JSX.Element => {
                   OPENSRP_MANIFEST_ENDPOINT,
                   dispatch,
                   customFetchOptions
-                ).catch(() => sendErrorNotification(t('An error occurred')))
+                ).catch(() => sendErrorNotification(t('There was a problem when making release')))
               }
             >
               {t('Make Release')}

--- a/packages/form-config-antd/src/components/DraftFileList/tests/index.test.tsx
+++ b/packages/form-config-antd/src/components/DraftFileList/tests/index.test.tsx
@@ -382,7 +382,9 @@ describe('components/Antd/DraftFileList', () => {
     });
     wrapper.update();
 
-    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem when making release');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'An error occurred while uploading the file'
+    );
   });
 
   it('renders correctly if manifest fetch is empty', async () => {

--- a/packages/form-config-antd/src/components/DraftFileList/tests/index.test.tsx
+++ b/packages/form-config-antd/src/components/DraftFileList/tests/index.test.tsx
@@ -354,7 +354,7 @@ describe('components/Antd/DraftFileList', () => {
     });
 
     wrapper.update();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem downloading this file');
     wrapper.unmount();
   });
 
@@ -382,7 +382,7 @@ describe('components/Antd/DraftFileList', () => {
     });
     wrapper.update();
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem when making release');
   });
 
   it('renders correctly if manifest fetch is empty', async () => {

--- a/packages/form-config-antd/src/components/FileList/TableActions/index.tsx
+++ b/packages/form-config-antd/src/components/FileList/TableActions/index.tsx
@@ -59,7 +59,7 @@ const TableActions = (props: TableActionsProps): JSX.Element => {
               isJsonValidator,
               customFetchOptions
             ).catch(() => {
-              sendErrorNotification(t('An error occurred'));
+              sendErrorNotification(t('There was a problem downloading this file'));
             })
           }
         >

--- a/packages/form-config-antd/src/components/FileList/index.tsx
+++ b/packages/form-config-antd/src/components/FileList/index.tsx
@@ -99,7 +99,7 @@ const FileList = (props: FileListPropTypes): JSX.Element => {
         dispatch,
         customFetchOptions
       )
-        .catch(() => sendErrorNotification('An error occurred'))
+        .catch(() => sendErrorNotification('There was a problem fetching manifests'))
         .finally(() => setLoading(false));
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
     [

--- a/packages/form-config-antd/src/components/FileList/tests/index.test.tsx
+++ b/packages/form-config-antd/src/components/FileList/tests/index.test.tsx
@@ -398,7 +398,7 @@ describe('components/Antd/FileList', () => {
     });
     wrapper.update();
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching manifests');
     expect(wrapper.find('tbody').find('tr').find('td').find('div.ant-empty-image')).toHaveLength(1);
 
     wrapper.unmount();
@@ -442,7 +442,7 @@ describe('components/Antd/FileList', () => {
     });
 
     wrapper.update();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem downloading this file');
     expect(downloadSpy).not.toHaveBeenCalled();
     wrapper.unmount();
   });

--- a/packages/form-config-antd/src/components/ReleaseList/index.tsx
+++ b/packages/form-config-antd/src/components/ReleaseList/index.tsx
@@ -73,7 +73,7 @@ const ReleaseList = (props: ReleaseListProps): JSX.Element => {
       dispatch,
       customFetchOptions
     )
-      .catch(() => sendErrorNotification(t('An error occurred')))
+      .catch(() => sendErrorNotification(t('There was a problem fetching release files')))
       .finally(() => {
         setLoading(false);
       });

--- a/packages/form-config-antd/src/components/ReleaseList/tests/index.test.tsx
+++ b/packages/form-config-antd/src/components/ReleaseList/tests/index.test.tsx
@@ -184,7 +184,9 @@ describe('components/Antd/ReleaseList', () => {
     });
     wrapper.update();
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem fetching release files'
+    );
     expect(wrapper.find('tbody').find('tr').find('td').find('div.ant-empty-image')).toHaveLength(1);
 
     wrapper.unmount();

--- a/packages/form-config/src/components/DraftFiles/index.tsx
+++ b/packages/form-config/src/components/DraftFiles/index.tsx
@@ -233,7 +233,7 @@ const ManifestDraftFiles = (props: ManifestDraftFilesProps): JSX.Element => {
               manifestEndPoint,
               undefined,
               getPayload
-            ).catch(() => displayAlertError('An error occurred'))
+            ).catch(() => displayAlertError('There was a problem when making release'))
           }
         >
           {makeReleaseLabel}

--- a/packages/form-config/src/components/DraftFiles/index.tsx
+++ b/packages/form-config/src/components/DraftFiles/index.tsx
@@ -233,7 +233,7 @@ const ManifestDraftFiles = (props: ManifestDraftFilesProps): JSX.Element => {
               manifestEndPoint,
               undefined,
               getPayload
-            ).catch(() => displayAlertError('There was a problem when making release'))
+            ).catch(() => displayAlertError('An error occurred while uploading the file'))
           }
         >
           {makeReleaseLabel}

--- a/packages/form-config/src/components/DraftFiles/tests/index.test.tsx
+++ b/packages/form-config/src/components/DraftFiles/tests/index.test.tsx
@@ -269,7 +269,7 @@ describe('components/DraftFiles', () => {
       await flushPromises();
     });
     wrapper.update();
-    expect(props.customAlert).toHaveBeenCalledWith('There was a problem when making release', {
+    expect(props.customAlert).toHaveBeenCalledWith('An error occurred while uploading the file', {
       type: 'error',
     });
   });

--- a/packages/form-config/src/components/DraftFiles/tests/index.test.tsx
+++ b/packages/form-config/src/components/DraftFiles/tests/index.test.tsx
@@ -269,7 +269,9 @@ describe('components/DraftFiles', () => {
       await flushPromises();
     });
     wrapper.update();
-    expect(props.customAlert).toHaveBeenCalledWith('An error occurred', { type: 'error' });
+    expect(props.customAlert).toHaveBeenCalledWith('There was a problem when making release', {
+      type: 'error',
+    });
   });
 
   it('renders correctly if manifest fetch is empty', async () => {

--- a/packages/form-config/src/components/FilesList/index.tsx
+++ b/packages/form-config/src/components/FilesList/index.tsx
@@ -112,7 +112,7 @@ const ManifestFilesList = (props: ManifestFilesListProps): JSX.Element => {
         undefined,
         getPayload
       )
-        .catch(() => displayAlertError(t('An error occurred')))
+        .catch(() => displayAlertError(t('There was a problem fetching manifest files')))
         .finally(() => setLoading(false));
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
     [baseURL, customAlert, endpoint, removeFiles, fetchFiles, formVersion, getPayload, accessToken]

--- a/packages/form-config/src/components/FilesList/tests/index.test.tsx
+++ b/packages/form-config/src/components/FilesList/tests/index.test.tsx
@@ -258,7 +258,9 @@ describe('components/manifestFiles', () => {
     });
     wrapper.update();
 
-    expect(props.customAlert).toHaveBeenCalledWith('An error occurred', { type: 'error' });
+    expect(props.customAlert).toHaveBeenCalledWith('There was a problem fetching manifest files', {
+      type: 'error',
+    });
     expect(wrapper.find('.tbody .tr')).toHaveLength(0);
 
     wrapper.unmount();

--- a/packages/form-config/src/components/Releases/index.tsx
+++ b/packages/form-config/src/components/Releases/index.tsx
@@ -82,7 +82,7 @@ const ManifestReleases = (props: ManifestReleasesProps & ReleasesDefaultProps) =
     if (data.length < 1) {
       setLoading(true);
       fetchReleaseFiles(accessToken, baseURL, fetchReleases, endpoint, undefined, getPayload)
-        .catch(() => displayAlertError(t('An error occurred')))
+        .catch(() => displayAlertError(t('There was a problem fetching release files')))
         .finally(() => setLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/form-config/src/components/Releases/tests/index.test.tsx
+++ b/packages/form-config/src/components/Releases/tests/index.test.tsx
@@ -142,7 +142,9 @@ describe('components/Releases', () => {
     });
     wrapper.update();
 
-    expect(props.customAlert).toHaveBeenCalledWith('An error occurred', { type: 'error' });
+    expect(props.customAlert).toHaveBeenCalledWith('There was a problem fetching release files', {
+      type: 'error',
+    });
     expect(wrapper.find('.tbody .tr')).toHaveLength(0);
 
     wrapper.unmount();

--- a/packages/form-config/src/components/UploadFile/index.tsx
+++ b/packages/form-config/src/components/UploadFile/index.tsx
@@ -100,9 +100,9 @@ const UploadConfigFile = (props: UploadConfigFileProps & UploadDefaultProps) => 
           endpoint
         ).catch(() => {
           if (isEditMode) {
-            displayAlertError(t('There was a problem updating file'));
+            displayAlertError(t('There was a problem updating the file'));
           } else {
-            displayAlertError(t('There was a problem when creating file'));
+            displayAlertError(t('There was a problem while creating the file'));
           }
         });
       }}

--- a/packages/form-config/src/components/UploadFile/index.tsx
+++ b/packages/form-config/src/components/UploadFile/index.tsx
@@ -99,7 +99,11 @@ const UploadConfigFile = (props: UploadConfigFileProps & UploadDefaultProps) => 
           displayAlertError,
           endpoint
         ).catch(() => {
-          displayAlertError(t('An error occurred'));
+          if (isEditMode) {
+            displayAlertError(t('There was a problem updating file'));
+          } else {
+            displayAlertError(t('There was a problem when creating file'));
+          }
         });
       }}
     >

--- a/packages/form-config/src/components/UploadFile/tests/index.test.tsx
+++ b/packages/form-config/src/components/UploadFile/tests/index.test.tsx
@@ -233,7 +233,7 @@ describe('components/UploadFile', () => {
       await flushPromises();
     });
     expect(fetch).not.toHaveBeenCalled();
-    expect(props.customAlert).toHaveBeenCalledWith('An error occurred', {
+    expect(props.customAlert).toHaveBeenCalledWith('There was a problem when creating file', {
       type: 'error',
     });
     wrapper.unmount();

--- a/packages/form-config/src/components/UploadFile/tests/index.test.tsx
+++ b/packages/form-config/src/components/UploadFile/tests/index.test.tsx
@@ -233,7 +233,7 @@ describe('components/UploadFile', () => {
       await flushPromises();
     });
     expect(fetch).not.toHaveBeenCalled();
-    expect(props.customAlert).toHaveBeenCalledWith('There was a problem when creating file', {
+    expect(props.customAlert).toHaveBeenCalledWith('There was a problem while creating the file', {
       type: 'error',
     });
     wrapper.unmount();

--- a/packages/inventory/src/components/InventoryItemForm/index.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/index.tsx
@@ -215,7 +215,7 @@ const InventoryItemForm: React.FC<InventoryItemFormProps> = (props: InventoryIte
 
           submitForm(payload, openSRPBaseURL, setSubmitting, setIfDoneHere, t, inventoryID).catch(
             (_: Error) => {
-              sendErrorNotification(t('There was a problem when submitting this form'));
+              sendErrorNotification(t('There was a problem while submitting this form'));
             }
           );
         }}

--- a/packages/inventory/src/components/InventoryItemForm/index.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/index.tsx
@@ -215,7 +215,7 @@ const InventoryItemForm: React.FC<InventoryItemFormProps> = (props: InventoryIte
 
           submitForm(payload, openSRPBaseURL, setSubmitting, setIfDoneHere, t, inventoryID).catch(
             (_: Error) => {
-              sendErrorNotification(t('An error occurred'));
+              sendErrorNotification(t('There was a problem when submitting this form'));
             }
           );
         }}

--- a/packages/inventory/src/components/InventoryItemForm/tests/index.test.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/tests/index.test.tsx
@@ -330,7 +330,7 @@ describe('components/InventoryItemForm', () => {
     await act(async () => {
       await flushPromises();
     });
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating inventory');
     wrapper.unmount();
   });
 
@@ -501,7 +501,7 @@ describe('components/InventoryItemForm', () => {
         method: 'PUT',
       },
     ]);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem updating inventory');
     wrapper.unmount();
   });
 
@@ -597,7 +597,9 @@ describe('components/InventoryItemForm', () => {
     });
 
     expect(fetch.mock.calls).toHaveLength(0);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem when submitting this form'
+    );
     wrapper.unmount();
   });
 

--- a/packages/inventory/src/components/InventoryItemForm/tests/index.test.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/tests/index.test.tsx
@@ -598,7 +598,7 @@ describe('components/InventoryItemForm', () => {
 
     expect(fetch.mock.calls).toHaveLength(0);
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There was a problem when submitting this form'
+      'There was a problem while submitting this form'
     );
     wrapper.unmount();
   });

--- a/packages/inventory/src/components/InventoryItemForm/tests/utils.test.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/tests/utils.test.tsx
@@ -147,7 +147,7 @@ describe('components/InventoryItemForm/utils/submitForm', () => {
         method: 'POST',
       },
     ]);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating inventory');
     expect(setSubmittingMock.mock.calls).toHaveLength(2);
     expect(setSubmittingMock.mock.calls[0][0]).toEqual(true);
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);
@@ -187,7 +187,7 @@ describe('components/InventoryItemForm/utils/submitForm', () => {
         method: 'PUT',
       },
     ]);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem updating inventory');
     expect(setSubmittingMock.mock.calls).toHaveLength(2);
     expect(setSubmittingMock.mock.calls[0][0]).toEqual(true);
     expect(setSubmittingMock.mock.calls[1][0]).toEqual(false);

--- a/packages/inventory/src/components/InventoryItemForm/utils.tsx
+++ b/packages/inventory/src/components/InventoryItemForm/utils.tsx
@@ -63,7 +63,7 @@ export const submitForm = async (
         setIfDoneHere(true);
       })
       .catch((_: HTTPError) => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem creating inventory'));
       })
       .finally(() => {
         setSubmitting(false);
@@ -83,7 +83,7 @@ export const submitForm = async (
         setIfDoneHere(true);
       })
       .catch((_: HTTPError) => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem updating inventory'));
       })
       .finally(() => {
         setSubmitting(false);

--- a/packages/inventory/src/containers/InventoryAddEdit/index.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/index.tsx
@@ -133,7 +133,7 @@ const InventoryAddEdit: React.FC<InventoryAddEditProps> = (props: InventoryAddEd
         setProducts(response);
       })
       .catch((_: HTTPError) => {
-        sendErrorNotification(t('There was a problem fetching Product Catalogue'));
+        sendErrorNotification(t('There was a problem fetching the Product Catalogue'));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/inventory/src/containers/InventoryAddEdit/index.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/index.tsx
@@ -106,7 +106,7 @@ const InventoryAddEdit: React.FC<InventoryAddEditProps> = (props: InventoryAddEd
           fetchLocationUnitsCreator([response]);
         })
         .catch((_: HTTPError) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching Location Unit'));
         })
         .finally(() => {
           setIsLoading(false);
@@ -133,7 +133,7 @@ const InventoryAddEdit: React.FC<InventoryAddEditProps> = (props: InventoryAddEd
         setProducts(response);
       })
       .catch((_: HTTPError) => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem fetching Product Catalogue'));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -165,7 +165,7 @@ const InventoryAddEdit: React.FC<InventoryAddEditProps> = (props: InventoryAddEd
           fetchInventoriesCreator(response);
         })
         .catch((_: HTTPError) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching inventories'));
         });
     }
   }, [

--- a/packages/inventory/src/containers/InventoryAddEdit/tests/utils.test.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/tests/utils.test.tsx
@@ -74,7 +74,7 @@ describe('containers/InventoryAddEdit/utils/fetchSettings', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem fetching settings');
     expect(setSettingsMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/inventory/src/containers/InventoryAddEdit/utils.tsx
+++ b/packages/inventory/src/containers/InventoryAddEdit/utils.tsx
@@ -27,5 +27,5 @@ export const fetchSettings = (
   service
     .list(params)
     .then((response: Setting[]) => setSettings(response))
-    .catch(() => sendErrorNotification(t('An error occurred')));
+    .catch(() => sendErrorNotification(t('There was a problem fetching settings')));
 };

--- a/packages/keycloak-user-management/src/components/CreateEditUser/index.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUser/index.tsx
@@ -106,7 +106,7 @@ const CreateEditUser: React.FC<CreateEditPropTypes> = (props: CreateEditPropType
         .list()
         .then((response: UserGroup[]) => setUserGroups(response))
         .catch((_: Error) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching User Group'));
         })
         .finally(() => setUserGroupsLoading(false));
     }
@@ -125,7 +125,7 @@ const CreateEditUser: React.FC<CreateEditPropTypes> = (props: CreateEditPropType
           if (response) fetchKeycloakUsersCreator([response]);
         })
         .catch((_: Error) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching User'));
         })
         .finally(() => setKeyCloakUserLoading(false));
     }
@@ -147,7 +147,7 @@ const CreateEditUser: React.FC<CreateEditPropTypes> = (props: CreateEditPropType
           setAssignedUserGroups(response);
         })
         .catch((_: Error) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching User Group'));
         })
         .finally(() => setUserGroupLoading(false));
     }
@@ -165,7 +165,7 @@ const CreateEditUser: React.FC<CreateEditPropTypes> = (props: CreateEditPropType
           setPractitioner(res);
         })
         .catch((_: Error) => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching Practitioner details'));
         })
         .finally(() => setPractitionerLoading(false));
     }

--- a/packages/keycloak-user-management/src/components/CreateEditUser/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUser/tests/index.test.tsx
@@ -388,7 +388,7 @@ describe('components/CreateEditUser', () => {
       wrapper.update();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching User');
     wrapper.unmount();
   });
 

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/Form.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/Form.tsx
@@ -182,7 +182,7 @@ const UserGroupForm: React.FC<UserGroupFormProps> = (props: UserGroupFormProps) 
             delete values.roles;
             setIsSubmitting(true);
             submitForm({ ...initialValues, ...values }, keycloakBaseURL, setIsSubmitting, t).catch(
-              () => sendErrorNotification(t('An error occurred'))
+              () => sendErrorNotification(t('There was a problem submitting the form'))
             );
           }}
         >

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/index.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/index.tsx
@@ -109,7 +109,7 @@ const CreateEditUserGroup: React.FC<CreateEditGroupPropTypes> = (
         assignedRolesPromise,
         effectiveRolesPromise,
       ])
-        .catch(() => sendErrorNotification(t('There was a problem fetching group')))
+        .catch(() => sendErrorNotification(t('There was a problem fetching user groups')))
         .finally(() => setIsLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/index.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/index.tsx
@@ -109,7 +109,7 @@ const CreateEditUserGroup: React.FC<CreateEditGroupPropTypes> = (
         assignedRolesPromise,
         effectiveRolesPromise,
       ])
-        .catch(() => sendErrorNotification(t('An error occurred')))
+        .catch(() => sendErrorNotification(t('There was a problem fetching group')))
         .finally(() => setIsLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/tests/index.test.tsx
@@ -236,7 +236,7 @@ describe('components/CreateEditUserGroup', () => {
       wrapper.update();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching User Group');
     wrapper.unmount();
   });
 

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/tests/utils.test.tsx
@@ -80,7 +80,7 @@ describe('dataLoading', () => {
       throw e;
     });
     await flushPromises();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching User Group');
   });
 
   it('assignRoles works correctly', async () => {
@@ -115,7 +115,7 @@ describe('dataLoading', () => {
       }
     );
     await flushPromises();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem assigning roles');
   });
 
   it('removeAssignedRoles works correctly', async () => {
@@ -158,7 +158,9 @@ describe('dataLoading', () => {
       throw e;
     });
     await flushPromises();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem removing assigned roles'
+    );
   });
 
   it('fetchRoleMappings fetches available roles', async () => {
@@ -249,7 +251,9 @@ describe('dataLoading', () => {
       throw e;
     });
     await flushPromises();
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem fetching role mappings'
+    );
   });
 
   it('submits group creation correctly', async () => {
@@ -344,7 +348,7 @@ describe('dataLoading', () => {
       await flushPromises();
     });
     expect(notificationErrorMock).toBeCalledTimes(1);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating User Group');
     expect(historyPushMock).not.toHaveBeenCalled();
   });
 
@@ -358,6 +362,6 @@ describe('dataLoading', () => {
       await flushPromises();
     });
     expect(notificationErrorMock).toBeCalledTimes(1);
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem editing User Group');
   });
 });

--- a/packages/keycloak-user-management/src/components/CreateEditUserGroup/utils.tsx
+++ b/packages/keycloak-user-management/src/components/CreateEditUserGroup/utils.tsx
@@ -40,7 +40,7 @@ export const fetchRoleMappings = async (
       setRolesAction(response);
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching role mappings'));
     });
 };
 
@@ -76,7 +76,7 @@ export const removeAssignedRoles = async (
       sendSuccessNotification(t('Role Mappings Updated Successfully'));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem removing assigned roles'));
     });
 };
 
@@ -112,7 +112,7 @@ export const assignRoles = async (
       sendSuccessNotification(t('Role Mappings Updated Successfully'));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem assigning roles'));
     });
 };
 
@@ -138,7 +138,7 @@ export const fetchSingleGroup = async (
       dispatch(fetchKeycloakUserGroups([response]));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching User Group'));
     });
 };
 
@@ -153,7 +153,7 @@ export const submitForm = async (
     serve
       .update(values)
       .then(() => sendSuccessNotification(t('User Group edited successfully')))
-      .catch((_: Error) => sendErrorNotification(t('An error occurred')))
+      .catch((_: Error) => sendErrorNotification(t('There was a problem editing User Group')))
       .finally(() => {
         history.push(URL_USER_GROUPS);
         setSubmittingCallback(false);
@@ -168,7 +168,7 @@ export const submitForm = async (
         newUUID = locationStr[locationStr.length - 1];
         sendSuccessNotification(t('User Group created successfully'));
       })
-      .catch((_: Error) => sendErrorNotification(t('An error occurred')))
+      .catch((_: Error) => sendErrorNotification(t('There was a problem creating User Group')))
       .finally(() => {
         setSubmittingCallback(false);
         if (newUUID) {

--- a/packages/keycloak-user-management/src/components/UserGroupsList/index.tsx
+++ b/packages/keycloak-user-management/src/components/UserGroupsList/index.tsx
@@ -97,7 +97,7 @@ export const UserGroupsList: React.FC<UserGroupListTypes> = (props: UserGroupLis
     ['fetchKeycloakUserGroups', KEYCLOAK_URL_USER_GROUPS, keycloakBaseURL],
     () => new KeycloakService(KEYCLOAK_URL_USER_GROUPS, keycloakBaseURL).list(),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching User Groups')),
       onSuccess: (response: KeycloakUserGroup[]) => dispatch(fetchKeycloakUserGroups(response)),
     }
   );
@@ -111,7 +111,7 @@ export const UserGroupsList: React.FC<UserGroupListTypes> = (props: UserGroupLis
     () => loadGroupDetails(groupId as string, keycloakBaseURL),
     {
       enabled: groupId !== null,
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Group Details')),
     }
   );
 
@@ -124,7 +124,7 @@ export const UserGroupsList: React.FC<UserGroupListTypes> = (props: UserGroupLis
     () => loadGroupMembers(groupId as string, keycloakBaseURL),
     {
       enabled: groupId !== null,
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Group Members')),
     }
   );
 

--- a/packages/keycloak-user-management/src/components/UserGroupsList/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/UserGroupsList/tests/index.test.tsx
@@ -188,7 +188,7 @@ describe('components/UserGroupsList', () => {
       await flushPromises();
       wrapper.update();
     });
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching User Groups');
   });
 
   it('shows table with no data if user groups list from api is empty', async () => {

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/tests/utils.test.tsx
@@ -114,7 +114,7 @@ describe('components/UserList/utils/deleteUser', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem fetching practitioner');
   });
 
   it('handles API error when calling the fetch endpoints', async () => {
@@ -143,6 +143,6 @@ describe('components/UserList/utils/deleteUser', () => {
     ]);
 
     expect(removeUsersMock).not.toHaveBeenCalled();
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem fetching practitioner');
   });
 });

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
@@ -34,7 +34,7 @@ export const deleteUser = async (
     userId,
     opensrpBaseURL
   ).catch(() => {
-    sendErrorNotification(t('There was a problem deleting the user'));
+    sendErrorNotification(t('There was a problem fetching practitioner'));
     // stop loader
     return undefined;
   });
@@ -62,7 +62,7 @@ export const deleteUser = async (
       sendSuccessNotification(t('Practitioner deactivated successfully'));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('There was a problem deleting User'));
+      sendErrorNotification(t('There was a problem deleting User and Practitioner'));
     });
 };
 

--- a/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/TableActions/utils.tsx
@@ -34,7 +34,7 @@ export const deleteUser = async (
     userId,
     opensrpBaseURL
   ).catch(() => {
-    sendErrorNotification(t('An error occurred'));
+    sendErrorNotification(t('There was a problem deleting the user'));
     // stop loader
     return undefined;
   });
@@ -62,7 +62,7 @@ export const deleteUser = async (
       sendSuccessNotification(t('Practitioner deactivated successfully'));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem deleting User'));
     });
 };
 

--- a/packages/keycloak-user-management/src/components/UserList/index.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/index.tsx
@@ -118,7 +118,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
       const practitioner: Practitioner | undefined = await serve.read(userId);
       return practitioner;
     } catch (error) {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching Practitioner tied to this User'));
       return undefined;
     }
   };
@@ -130,7 +130,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
       const organizations: Organization[] = await serve.read(practitionerId);
       return organizations;
     } catch (error) {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching teams assigned to Practitioner'));
       return [];
     }
   };
@@ -157,7 +157,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
               });
             })
             .catch(() => {
-              sendErrorNotification(t('An error occurred'));
+              sendErrorNotification(t('There was a problem fetching assigned teams'));
             });
         } else {
           setUserDetails({
@@ -168,7 +168,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
         }
       })
       .catch(() => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem fetching practitioner'));
       });
   };
 
@@ -203,7 +203,7 @@ const UserList = (props: UserListTypes): JSX.Element => {
           <Space>
             <PaginateData<KeycloakUser>
               queryFn={FetchData}
-              onError={() => sendErrorNotification(t('An error occurred'))}
+              onError={() => sendErrorNotification(t('There was a problem fetching Users'))}
               queryPram={{ searchParam }}
               pageSize={usersPageSize}
               queryid={UserQueryId}

--- a/packages/keycloak-user-management/src/components/UserList/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/UserList/tests/index.test.tsx
@@ -332,7 +332,7 @@ describe('components/UserList', () => {
     expect(wrapper.text()).toMatchInlineSnapshot(
       `"User ManagementAdd UserFirst NameLast NameUsernameActionsNo data"`
     );
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching Users');
   });
 
   it('sorting works', async () => {

--- a/packages/keycloak-user-management/src/components/UserRolesList/index.tsx
+++ b/packages/keycloak-user-management/src/components/UserRolesList/index.tsx
@@ -66,7 +66,7 @@ export const UserRolesList: React.FC<Props & RouteComponentProps> = (
     if (isLoading) {
       fetchAllRoles(keycloakBaseURL, dispatch, t)
         .catch(() => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem fetching roles'));
         })
         .finally(() => setIsLoading(false));
     }

--- a/packages/keycloak-user-management/src/components/UserRolesList/tests/index.test.tsx
+++ b/packages/keycloak-user-management/src/components/UserRolesList/tests/index.test.tsx
@@ -170,7 +170,7 @@ describe('components/UserRolesList', () => {
       await flushPromises();
       wrapper.update();
     });
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem fetching realm roles');
   });
 
   it('shows table with no data if user roles list from api is empty', async () => {

--- a/packages/keycloak-user-management/src/components/UserRolesList/utils.tsx
+++ b/packages/keycloak-user-management/src/components/UserRolesList/utils.tsx
@@ -25,6 +25,6 @@ export const fetchAllRoles = async (
       dispatch(fetchKeycloakUserRoles(response));
     })
     .catch((_: Error) => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem fetching realm roles'));
     });
 };

--- a/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/index.tsx
@@ -128,7 +128,10 @@ const UserForm: FC<UserFormProps> = (props: UserFormProps) => {
               t
             )
               .catch((_: Error) => {
-                sendErrorNotification(t('An error occurred'));
+                if (props.initialValues.id) {
+                  sendErrorNotification(t('There was a problem updating user details'));
+                }
+                sendErrorNotification(t('There was a problem creating User'));
               })
               .finally(() => setSubmitting(false));
           }}

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -363,7 +363,7 @@ describe('forms/utils/submitForm', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating user');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating the user');
     expect(historyPushMock).not.toHaveBeenCalled();
   });
 
@@ -384,7 +384,9 @@ describe('forms/utils/submitForm', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem updating user');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem updating the user profile'
+    );
   });
 
   it('marks user as practitioner successfully', async () => {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/tests/utils.test.tsx
@@ -363,7 +363,7 @@ describe('forms/utils/submitForm', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating user');
     expect(historyPushMock).not.toHaveBeenCalled();
   });
 
@@ -384,7 +384,7 @@ describe('forms/utils/submitForm', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem updating user');
   });
 
   it('marks user as practitioner successfully', async () => {
@@ -518,7 +518,7 @@ describe('forms/utils/submitForm', () => {
     await act(async () => {
       await flushPromises();
     });
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem creating practitioner');
   });
 
   it('updates practitioner values when user values update', async () => {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -201,7 +201,7 @@ export const submitForm = async (
     if (isEditMode) {
       sendErrorNotification(t('There was a problem updating user'));
     } else {
-      sendErrorNotification(t('There was a problem creating user '));
+      sendErrorNotification(t('There was a problem creating user'));
     }
   });
 

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -64,7 +64,13 @@ export const createOrEditPractitioners = async (
 
   // update or create new practitioner
   await practitionersService[requestType](payload)
-    .catch((_: Error) => sendErrorNotification(t('An error occurred')))
+    .catch((_: Error) => {
+      if (isEditMode) {
+        sendErrorNotification(t('There was a problem updating practitioner'));
+      } else {
+        sendErrorNotification(t('There was a problem creating practitioner'));
+      }
+    })
     .then(() => sendSuccessNotification(successMessage));
 
   if (!isEditMode) history.push(`${URL_USER_CREDENTIALS}/${payload.userId}`);
@@ -96,7 +102,7 @@ const createEditKeycloakUser = async (
       .then(() => {
         sendSuccessNotification(t('User edited successfully'));
         updateGroupsAndPractitionerCallback(keycloakUserPayload.id).catch(() =>
-          sendErrorNotification(t('An error occurred'))
+          sendErrorNotification(t('There was a problem updating groups and practitioners'))
         );
       })
       .catch((error) => {
@@ -111,7 +117,7 @@ const createEditKeycloakUser = async (
         sendSuccessNotification(t('User created successfully'));
         const keycloakUserId = getUserId(res);
         updateGroupsAndPractitionerCallback(keycloakUserId).catch(() =>
-          sendErrorNotification(t('An error occurred'))
+          sendErrorNotification(t('There was a problem updating groups and practitioners'))
         );
       })
       .catch((error) => {
@@ -192,7 +198,11 @@ export const submitForm = async (
     updateGroupsAndPractitioner,
     t
   ).catch(() => {
-    sendErrorNotification(t('An error occurred'));
+    if (isEditMode) {
+      sendErrorNotification(t('There was a problem updating user'));
+    } else {
+      sendErrorNotification(t('There was a problem creating user '));
+    }
   });
 
   if (isEditMode) {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -117,7 +117,7 @@ const createEditKeycloakUser = async (
         sendSuccessNotification(t('User created successfully'));
         const keycloakUserId = getUserId(res);
         updateGroupsAndPractitionerCallback(keycloakUserId).catch(() =>
-          sendErrorNotification(t('There was a problem updating groups and practitioners'))
+          sendErrorNotification(t('There was a problem creating groups and practitioners'))
         );
       })
       .catch((error) => {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -117,7 +117,7 @@ const createEditKeycloakUser = async (
         sendSuccessNotification(t('User created successfully'));
         const keycloakUserId = getUserId(res);
         updateGroupsAndPractitionerCallback(keycloakUserId).catch(() =>
-          sendErrorNotification(t('There was a problem creating groups and practitioners'))
+          sendErrorNotification(t('There was a problem creating group and practitioner'))
         );
       })
       .catch((error) => {

--- a/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
+++ b/packages/keycloak-user-management/src/components/forms/UserForm/utils.tsx
@@ -199,9 +199,9 @@ export const submitForm = async (
     t
   ).catch(() => {
     if (isEditMode) {
-      sendErrorNotification(t('There was a problem updating user'));
+      sendErrorNotification(t('There was a problem updating the user profile'));
     } else {
-      sendErrorNotification(t('There was a problem creating user'));
+      sendErrorNotification(t('There was a problem creating the user'));
     }
   });
 

--- a/packages/location-management/src/components/EditLocationUnit/index.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/index.tsx
@@ -151,7 +151,7 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
     LOCATION_UNIT_FIND_BY_PROPERTIES,
     () => getBaseTreeNode(opensrpBaseURL, filterByParentId),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Location Units')),
       select: (res: LocationUnit[]) => res,
     }
   );
@@ -162,7 +162,8 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
           return {
             queryKey: [LOCATION_HIERARCHY, location.id],
             queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
-            onError: () => sendErrorNotification(t('An error occurred')),
+            onError: () =>
+              sendErrorNotification(t('There was a problem fetching location hierachy')),
             select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res).model,
           };
         })
@@ -213,8 +214,10 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
         if (grandparenthierarchy && grandparenthierarchy.id)
           queryClient
             .invalidateQueries([LOCATION_HIERARCHY, grandparenthierarchy.id])
-            .catch(() => sendErrorNotification(t('An error occurred')));
-        else sendErrorNotification(t('An error occurred'));
+            .catch(() =>
+              sendErrorNotification(t('There was a problem fetching location hierachy'))
+            );
+        else sendErrorNotification(t('There was a problem getting the hierachy node'));
       }
       dispatch(fetchAllHierarchies([]));
     },

--- a/packages/location-management/src/components/EditLocationUnit/index.tsx
+++ b/packages/location-management/src/components/EditLocationUnit/index.tsx
@@ -163,7 +163,7 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
             queryKey: [LOCATION_HIERARCHY, location.id],
             queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
             onError: () =>
-              sendErrorNotification(t('There was a problem fetching location hierachy')),
+              sendErrorNotification(t('There was a problem fetching the location hierachy')),
             select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res).model,
           };
         })
@@ -215,7 +215,7 @@ const EditLocationUnit = (props: EditLocationUnitProps) => {
           queryClient
             .invalidateQueries([LOCATION_HIERARCHY, grandparenthierarchy.id])
             .catch(() =>
-              sendErrorNotification(t('There was a problem fetching location hierachy'))
+              sendErrorNotification(t('There was a problem fetching the location hierachy'))
             );
         else sendErrorNotification(t('There was a problem getting the hierachy node'));
       }

--- a/packages/location-management/src/components/LocationUnitGroupAddEdit/Form.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupAddEdit/Form.tsx
@@ -68,19 +68,19 @@ export const onSubmit = (
         history.goBack();
       })
       .catch(() => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem updating Location Unit Group'));
         setSubmitting(false);
       });
   } else {
     serve
       .create(payload)
       .then(() => {
-        sendSuccessNotification('Location Unit Group successfully');
+        sendSuccessNotification('Location Unit Group created successfully');
         setSubmitting(false);
         history.goBack();
       })
       .catch(() => {
-        sendErrorNotification(t('An error occurred'));
+        sendErrorNotification(t('There was a problem creating Location Unit Group'));
         setSubmitting(false);
       });
   }
@@ -116,7 +116,7 @@ export const Form: React.FC<Props> = (props: Props) => {
             setEditTitle(response.name);
             setIsLoading(false);
           })
-          .catch(() => sendErrorNotification(t('An error occurred')));
+          .catch(() => sendErrorNotification(t('There was a problem submitting ')));
       } else setIsLoading(false);
     }
   }, [isLoading, props.id, opensrpBaseURL, setEditTitle, t]);

--- a/packages/location-management/src/components/LocationUnitGroupAddEdit/Form.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupAddEdit/Form.tsx
@@ -116,7 +116,7 @@ export const Form: React.FC<Props> = (props: Props) => {
             setEditTitle(response.name);
             setIsLoading(false);
           })
-          .catch(() => sendErrorNotification(t('There was a problem submitting ')));
+          .catch(() => sendErrorNotification(t('There was a problem submitting the form')));
       } else setIsLoading(false);
     }
   }, [isLoading, props.id, opensrpBaseURL, setEditTitle, t]);

--- a/packages/location-management/src/components/LocationUnitGroupAddEdit/tests/Form.test.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupAddEdit/tests/Form.test.tsx
@@ -197,7 +197,7 @@ describe('location-management/src/components/LocationUnitGroupAddEdit', () => {
       wrapper.update();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem submitting the form');
 
     wrapper.unmount();
   });
@@ -228,7 +228,9 @@ describe('location-management/src/components/LocationUnitGroupAddEdit', () => {
       wrapper.update();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem creating Location Unit Group'
+    );
 
     wrapper.unmount();
   });
@@ -248,7 +250,9 @@ describe('location-management/src/components/LocationUnitGroupAddEdit', () => {
       await flushPromises();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem updating Location Unit Group'
+    );
   });
 
   it('render correct location unit group name in header', async () => {

--- a/packages/location-management/src/components/LocationUnitGroupList/Table.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupList/Table.tsx
@@ -32,7 +32,7 @@ export const onDelete = (record: LocationUnitGroup, opensrpBaseURL: string, t: T
   clientService
     .delete()
     .then(() => sendSuccessNotification('Successfully Deleted!'))
-    .catch(() => sendErrorNotification(t('An error occurred')));
+    .catch(() => sendErrorNotification(t('There was a problem deleting group')));
 };
 
 const Table: React.FC<Props> = (props: Props) => {

--- a/packages/location-management/src/components/LocationUnitGroupList/index.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupList/index.tsx
@@ -46,7 +46,7 @@ const LocationUnitGroupList: React.FC<Props> = (props: Props) => {
           dispatch(fetchLocationUnitGroups(response));
           setIsLoading(false);
         })
-        .catch(() => sendErrorNotification(t('An error occurred')));
+        .catch(() => sendErrorNotification(t('There was a problem fetching Location Unit Groups')));
     }
   });
 

--- a/packages/location-management/src/components/LocationUnitGroupList/tests/index.test.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupList/tests/index.test.tsx
@@ -86,6 +86,8 @@ describe('location-management/src/components/LocationUnitGroupList', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching Location Unit Groups'
+    );
   });
 });

--- a/packages/location-management/src/components/LocationUnitGroupList/tests/table.test.tsx
+++ b/packages/location-management/src/components/LocationUnitGroupList/tests/table.test.tsx
@@ -161,7 +161,7 @@ describe('location-management/src/components/LocationTagView', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith('There was a problem deleting group');
   });
 
   it('Should show table pagination options', () => {

--- a/packages/location-management/src/components/LocationUnitList/index.tsx
+++ b/packages/location-management/src/components/LocationUnitList/index.tsx
@@ -69,7 +69,7 @@ export async function loadSingleLocation(
     .then((res: LocationUnit) => {
       setDetail(res);
     })
-    .catch(() => sendErrorNotification(t('An error occurred')));
+    .catch(() => sendErrorNotification(t('There was a problem fetching Location Unit details')));
 }
 
 export const LocationUnitList: React.FC<Props> = (props: Props) => {
@@ -83,7 +83,7 @@ export const LocationUnitList: React.FC<Props> = (props: Props) => {
     LOCATION_UNIT_FIND_BY_PROPERTIES,
     () => getBaseTreeNode(opensrpBaseURL, filterByParentId),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Location Units')),
       select: (res: LocationUnit[]) => res,
     }
   );
@@ -102,7 +102,7 @@ export const LocationUnitList: React.FC<Props> = (props: Props) => {
       return {
         queryKey: [LOCATION_HIERARCHY, location.id],
         queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
-        onError: () => sendErrorNotification(t('An error occurred')),
+        onError: () => sendErrorNotification(t('There was a problem fetching location hierachy')),
         select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res),
       };
     })

--- a/packages/location-management/src/components/LocationUnitList/index.tsx
+++ b/packages/location-management/src/components/LocationUnitList/index.tsx
@@ -102,7 +102,8 @@ export const LocationUnitList: React.FC<Props> = (props: Props) => {
       return {
         queryKey: [LOCATION_HIERARCHY, location.id],
         queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
-        onError: () => sendErrorNotification(t('There was a problem fetching location hierachy')),
+        onError: () =>
+          sendErrorNotification(t('There was a problem fetching the location hierachy')),
         select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res),
       };
     })

--- a/packages/location-management/src/components/LocationUnitList/tests/index.test.tsx
+++ b/packages/location-management/src/components/LocationUnitList/tests/index.test.tsx
@@ -321,7 +321,9 @@ describe('location-management/src/components/LocationUnitList', () => {
       await flushPromises();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching Location Unit details'
+    );
     fetch.resetMocks();
   });
 
@@ -391,7 +393,9 @@ describe('location-management/src/components/LocationUnitList', () => {
       wrapper.update();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching Location Unit details'
+    );
     wrapper.unmount();
   });
 
@@ -417,7 +421,9 @@ describe('location-management/src/components/LocationUnitList', () => {
       wrapper.update();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching Location Unit details'
+    );
     wrapper.unmount();
   });
 

--- a/packages/location-management/src/components/NewLocationUnit/index.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/index.tsx
@@ -98,7 +98,7 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
             queryKey: [LOCATION_HIERARCHY, location.id],
             queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
             onError: () =>
-              sendErrorNotification(t('There was a problem fetching location hierachy')),
+              sendErrorNotification(t('There was a problem fetching the location hierachy')),
             // Todo : useQueries doesn't support select or types yet https://github.com/tannerlinsley/react-query/pull/1527
             select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res).model,
           };
@@ -136,7 +136,7 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
           queryClient
             .invalidateQueries([LOCATION_HIERARCHY, grandparenthierarchy])
             .catch(() =>
-              sendErrorNotification(t('There was a problem fetching location hierachy'))
+              sendErrorNotification(t('There was a problem fetching the location hierachy'))
             );
         else sendErrorNotification(t('There was a problem getting hierachy node'));
       }

--- a/packages/location-management/src/components/NewLocationUnit/index.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/index.tsx
@@ -86,7 +86,7 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
     LOCATION_UNIT_FIND_BY_PROPERTIES,
     () => getBaseTreeNode(opensrpBaseURL, filterByParentId),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Location Units')),
       select: (res: LocationUnit[]) => res,
     }
   );
@@ -97,7 +97,8 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
           return {
             queryKey: [LOCATION_HIERARCHY, location.id],
             queryFn: () => new OpenSRPService(LOCATION_HIERARCHY, opensrpBaseURL).read(location.id),
-            onError: () => sendErrorNotification(t('An error occurred')),
+            onError: () =>
+              sendErrorNotification(t('There was a problem fetching location hierachy')),
             // Todo : useQueries doesn't support select or types yet https://github.com/tannerlinsley/react-query/pull/1527
             select: (res: RawOpenSRPHierarchy) => generateJurisdictionTree(res).model,
           };
@@ -134,8 +135,10 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
         if (grandparenthierarchy)
           queryClient
             .invalidateQueries([LOCATION_HIERARCHY, grandparenthierarchy])
-            .catch(() => sendErrorNotification(t('An error occurred')));
-        else sendErrorNotification(t('An error occurred'));
+            .catch(() =>
+              sendErrorNotification(t('There was a problem fetching location hierachy'))
+            );
+        else sendErrorNotification(t('There was a problem getting hierachy node'));
       }
       dispatch(fetchAllHierarchies([]));
     },

--- a/packages/location-management/src/components/NewLocationUnit/index.tsx
+++ b/packages/location-management/src/components/NewLocationUnit/index.tsx
@@ -136,9 +136,9 @@ const NewLocationUnit = (props: NewLocationUnitProps) => {
           queryClient
             .invalidateQueries([LOCATION_HIERARCHY, grandparenthierarchy])
             .catch(() =>
-              sendErrorNotification(t('There was a problem fetching the location hierachy'))
+              sendErrorNotification(t('An error occurred while refreshing the location data.'))
             );
-        else sendErrorNotification(t('There was a problem getting hierachy node'));
+        else sendErrorNotification(t('There was a problem finding the location'));
       }
       dispatch(fetchAllHierarchies([]));
     },

--- a/packages/react-utils/src/index.tsx
+++ b/packages/react-utils/src/index.tsx
@@ -12,7 +12,6 @@ export * from './components/TableLayout';
 export * from './components/PaginateData';
 export * from './components/KeyValuePairs';
 export * from './helpers/fhir-utils';
-export * from './helpers/CustomError';
 export * from './hooks/useSimpleTabularView';
 export * from './hooks/useTabularViewWithLocalSearch';
 export * from './hooks/useSearchParams';

--- a/packages/react-utils/src/index.tsx
+++ b/packages/react-utils/src/index.tsx
@@ -12,6 +12,7 @@ export * from './components/TableLayout';
 export * from './components/PaginateData';
 export * from './components/KeyValuePairs';
 export * from './helpers/fhir-utils';
+export * from './helpers/CustomError';
 export * from './hooks/useSimpleTabularView';
 export * from './hooks/useTabularViewWithLocalSearch';
 export * from './hooks/useSearchParams';

--- a/packages/reports/src/components/DistrictReport/index.tsx
+++ b/packages/reports/src/components/DistrictReport/index.tsx
@@ -87,7 +87,7 @@ export const DistrictReport = ({ opensrpBaseURL }: DistrictReportProps) => {
     {
       // start fetching when userLocSettings hook succeeds
       enabled: userLocSettings.isSuccess && userLocSettings.data.uuid.length > 0,
-      onError: () => sendErrorNotification(t('There was a problem fetching location hierachy')),
+      onError: () => sendErrorNotification(t('There was a problem fetching the location hierachy')),
       onSuccess: (res: RawOpenSRPHierarchy) => {
         const hierarchy = generateJurisdictionTree(res);
         dispatch(fetchAllHierarchiesActionCreator([hierarchy.model]));

--- a/packages/reports/src/components/DistrictReport/index.tsx
+++ b/packages/reports/src/components/DistrictReport/index.tsx
@@ -87,7 +87,7 @@ export const DistrictReport = ({ opensrpBaseURL }: DistrictReportProps) => {
     {
       // start fetching when userLocSettings hook succeeds
       enabled: userLocSettings.isSuccess && userLocSettings.data.uuid.length > 0,
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching location hierachy')),
       onSuccess: (res: RawOpenSRPHierarchy) => {
         const hierarchy = generateJurisdictionTree(res);
         dispatch(fetchAllHierarchiesActionCreator([hierarchy.model]));
@@ -118,7 +118,7 @@ export const DistrictReport = ({ opensrpBaseURL }: DistrictReportProps) => {
           onFinish={() => {
             setSubmitting(true);
             submitForm(locationId, reportDate, opensrpBaseURL)
-              .catch(() => sendErrorNotification(t('An error occurred')))
+              .catch(() => sendErrorNotification(t('There was a problem submitting the form')))
               .finally(() => setSubmitting(false));
           }}
         >

--- a/packages/reports/src/components/DistrictReport/tests/index.test.tsx
+++ b/packages/reports/src/components/DistrictReport/tests/index.test.tsx
@@ -233,6 +233,8 @@ describe('DistrictReport', () => {
       wrapper.update();
     });
 
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem fetching location hierachy'
+    );
   });
 });

--- a/packages/reports/src/components/DistrictReport/tests/index.test.tsx
+++ b/packages/reports/src/components/DistrictReport/tests/index.test.tsx
@@ -234,7 +234,7 @@ describe('DistrictReport', () => {
     });
 
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There was a problem fetching location hierachy'
+      'There was a problem fetching the location hierachy'
     );
   });
 });

--- a/packages/server-settings/src/components/ServerSettingsView/index.tsx
+++ b/packages/server-settings/src/components/ServerSettingsView/index.tsx
@@ -102,7 +102,7 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
     if (settingIsSimilarToParent) {
       await settingsServe(row.settingMetadataId)
         .delete()
-        .catch(() => sendErrorNotification(t('An error occurred')))
+        .catch(() => sendErrorNotification(t('There was a problem deleting settings')))
         .then(async () => {
           await invalidateSettingsQueries();
         })
@@ -118,7 +118,7 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
       };
       await settingsServe(rest.settingMetadataId)
         .update(payload)
-        .catch(() => sendErrorNotification(t('An error occurred')))
+        .catch(() => sendErrorNotification(t('There was a problem updating settings')))
         .then(async () => {
           await invalidateSettingsQueries();
         })
@@ -130,7 +130,8 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
     SECURITY_AUTHENTICATE_ENDPOINT,
     () => new OpenSRPService(SECURITY_AUTHENTICATE_ENDPOINT, baseURL).list(),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () =>
+        sendErrorNotification(t('There was a problem authenticating User Location settings')),
       select: (res: { locations: RawOpenSRPHierarchy }) => res.locations,
       onSuccess: (userLocSettings) => {
         const processedHierarchy = generateJurisdictionTree(userLocSettings);
@@ -181,7 +182,7 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
           onClick={async () => {
             await settingsServe(row.settingMetadataId)
               .delete()
-              .catch(() => sendErrorNotification(t('An error occurred')))
+              .catch(() => sendErrorNotification(t('There was a problem deleting settings')))
               .then(async () => {
                 await invalidateSettingsQueries();
               })
@@ -202,7 +203,7 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
     [SETTINGS_ENDPOINT, currentLocation?.id ?? ''],
     async () => await getServerSettings(currentLocation?.id ?? ''),
     {
-      onError: () => sendErrorNotification(t('An error occurred')),
+      onError: () => sendErrorNotification(t('There was a problem fetching Server Settings')),
       select: (res: Setting[]) => res,
       enabled: !!currentLocation?.id,
     }

--- a/packages/server-settings/src/components/ServerSettingsView/index.tsx
+++ b/packages/server-settings/src/components/ServerSettingsView/index.tsx
@@ -130,8 +130,7 @@ export const ServerSettingsView: React.FC<Props> = (props: Props) => {
     SECURITY_AUTHENTICATE_ENDPOINT,
     () => new OpenSRPService(SECURITY_AUTHENTICATE_ENDPOINT, baseURL).list(),
     {
-      onError: () =>
-        sendErrorNotification(t('There was a problem authenticating User Location settings')),
+      onError: () => sendErrorNotification(t('There was a problem fetching user assignment data')),
       select: (res: { locations: RawOpenSRPHierarchy }) => res.locations,
       onSuccess: (userLocSettings) => {
         const processedHierarchy = generateJurisdictionTree(userLocSettings);

--- a/packages/server-settings/src/components/ServerSettingsView/tests/index.test.tsx
+++ b/packages/server-settings/src/components/ServerSettingsView/tests/index.test.tsx
@@ -405,7 +405,7 @@ describe('activate mission', () => {
       wrapper.update();
     });
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There was a problem authenticating User Location settings'
+      'There was a problem fetching user assignment data'
     );
 
     // broken page as well

--- a/packages/server-settings/src/components/ServerSettingsView/tests/index.test.tsx
+++ b/packages/server-settings/src/components/ServerSettingsView/tests/index.test.tsx
@@ -404,7 +404,9 @@ describe('activate mission', () => {
       await flushPromises();
       wrapper.update();
     });
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There was a problem authenticating User Location settings'
+    );
 
     // broken page as well
     expect(wrapper.text()).toMatchInlineSnapshot(`"ErrorSomething went wrongGo backGo home"`);

--- a/packages/team-management/src/components/ListView/index.tsx
+++ b/packages/team-management/src/components/ListView/index.tsx
@@ -198,7 +198,7 @@ const TeamAssignmentView = (props: TeamAssignmentViewProps) => {
 
       Promise.all([plansPromise, assignmentsPromise, organizationsPromise])
         .catch(() => {
-          sendErrorNotification(t('There waes a problem fetching Plans|Assignments|Organizations'));
+          sendErrorNotification(t('There was a problem fetching Plans|Assignments|Organizations'));
           setApiError(true);
         })
         .finally(() => {

--- a/packages/team-management/src/components/ListView/index.tsx
+++ b/packages/team-management/src/components/ListView/index.tsx
@@ -104,7 +104,7 @@ async function fetchOrgs(
     const getOrgs = await organizationsService.list(paginationParams);
     return getOrgs;
   } catch (_) {
-    sendErrorNotification(t('An error occurred'));
+    sendErrorNotification(t('There was a problem fetching organizations'));
     return [];
   }
 }
@@ -198,7 +198,7 @@ const TeamAssignmentView = (props: TeamAssignmentViewProps) => {
 
       Promise.all([plansPromise, assignmentsPromise, organizationsPromise])
         .catch(() => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There waes a problem fetching Plans|Assignments|Organizations'));
           setApiError(true);
         })
         .finally(() => {

--- a/packages/team-management/src/components/ListView/tests/index.test.tsx
+++ b/packages/team-management/src/components/ListView/tests/index.test.tsx
@@ -307,7 +307,7 @@ describe('List view Page', () => {
     });
     expect(notificationErrorMock).toHaveBeenCalled();
     expect(notificationErrorMock).toHaveBeenCalledWith(
-      'There waes a problem fetching Plans|Assignments|Organizations'
+      'There was a problem fetching Plans|Assignments|Organizations'
     );
     wrapper.unmount();
   });

--- a/packages/team-management/src/components/ListView/tests/index.test.tsx
+++ b/packages/team-management/src/components/ListView/tests/index.test.tsx
@@ -306,7 +306,9 @@ describe('List view Page', () => {
       wrapper.update();
     });
     expect(notificationErrorMock).toHaveBeenCalled();
-    expect(notificationErrorMock).toHaveBeenCalledWith('An error occurred');
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'There waes a problem fetching Plans|Assignments|Organizations'
+    );
     wrapper.unmount();
   });
 

--- a/packages/team-management/src/components/TeamsAddEdit/Form.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/Form.tsx
@@ -79,7 +79,7 @@ export function onSubmit(
       await SetPractitioners(opensrpBaseURL, practitioner, toAdd, toRem, Teamid, t);
       history.goBack();
     })
-    .catch(() => sendErrorNotification(t('An error occurred')))
+    .catch(() => sendErrorNotification(t('There was a problem updating teams')))
     .finally(() => setIsSubmitting(false));
 }
 
@@ -108,7 +108,7 @@ async function SetPractitioners(
     const serve = new OpenSRPService(PRACTITIONER_DEL, opensrpBaseURL);
     serve
       .delete({ practitioner: `${prac}`, organization: id })
-      .catch(() => sendErrorNotification(t('An error occurred')));
+      .catch(() => sendErrorNotification(t('There was a problem deleting practitioner')));
   });
 
   // Api Call to add practitioners
@@ -124,7 +124,9 @@ async function SetPractitioners(
   });
   if (toAdd.length) {
     const serve = new OpenSRPService(PRACTITIONER_POST, opensrpBaseURL);
-    await serve.create(payload).catch(() => sendErrorNotification(t('An error occurred')));
+    await serve
+      .create(payload)
+      .catch(() => sendErrorNotification(t('There was a problem adding practitioner')));
   }
 
   sendSuccessNotification(t('Successfully Assigned Practitioners'));

--- a/packages/team-management/src/components/TeamsAddEdit/index.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/index.tsx
@@ -80,7 +80,7 @@ function setupInitialValue(
         practitionersList: response.practitioners,
       });
     })
-    .catch(() => sendErrorNotification(t('An error occurred')));
+    .catch(() => sendErrorNotification(t('There was a problem fetching the team details')));
 }
 
 export interface Props {
@@ -120,7 +120,7 @@ async function fetchPractitioners(
     const practitioners: Practitioner[] = await serve.list(paginationParams);
     return practitioners;
   } catch (_) {
-    sendErrorNotification(t('An error occurred'));
+    sendErrorNotification(t('There was a problem fetching practitioners'));
     return [];
   }
 }
@@ -195,7 +195,9 @@ export const TeamsAddEdit: React.FC<Props> = (props: Props) => {
           const filteredResponse = response.filter((practitioner) => practitioner.active);
           setPractitionersRole(filteredResponse);
         })
-        .catch(() => sendErrorNotification(t('An error occurred')));
+        .catch(() =>
+          sendErrorNotification(t('There was a problem fetching assigned practitioners'))
+        );
     }
   }, [disableTeamMemberReassignment, opensrpBaseURL, t]);
 
@@ -245,7 +247,7 @@ export const TeamsAddEdit: React.FC<Props> = (props: Props) => {
 
           setPractitioners(filteredResponse);
         })
-        .catch(() => sendErrorNotification(t('An error occurred')));
+        .catch(() => sendErrorNotification(t('There was a problem fetching practitioners')));
     }
   }, [disableTeamMemberReassignment, opensrpBaseURL, paginationSize, practitionersRole, t]);
 

--- a/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/Form.test.tsx
@@ -202,7 +202,7 @@ describe('Team-management/TeamsAddEdit/Form', () => {
       await flushPromises();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith('There was a problem updating teams');
   });
 
   it('Create Team', async () => {

--- a/packages/team-management/src/components/TeamsAddEdit/tests/index.test.tsx
+++ b/packages/team-management/src/components/TeamsAddEdit/tests/index.test.tsx
@@ -177,7 +177,9 @@ describe('Team-management/TeamsAddEdit/TeamsAddEdit', () => {
       await flushPromises();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem fetching the team details'
+    );
   });
 
   it('test getPractitionerDetail', async () => {

--- a/packages/team-management/src/components/TeamsView/Table.tsx
+++ b/packages/team-management/src/components/TeamsView/Table.tsx
@@ -79,7 +79,7 @@ const Table: React.FC<Props> = (props: Props) => {
   return (
     <PaginateData<Organization>
       queryFn={fetchOrgs}
-      onError={() => sendErrorNotification(t('An error occurred'))}
+      onError={() => sendErrorNotification(t('There was a problem fetching Organizations'))}
       queryPram={{ searchParam }}
       pageSize={5}
       queryid="Teams"

--- a/packages/team-management/src/components/TeamsView/index.tsx
+++ b/packages/team-management/src/components/TeamsView/index.tsx
@@ -85,11 +85,11 @@ export const populateTeamDetails = (
           setAssignedLocations(locations);
         })
         .catch(() => {
-          sendErrorNotification(t('An error occurred'));
+          sendErrorNotification(t('There was a problem getting jurisdictions'));
         });
     })
     .catch(() => {
-      sendErrorNotification(t('An error occurred'));
+      sendErrorNotification(t('There was a problem populating the teams details'));
     })
     .finally(() => setDetail(row));
 };

--- a/packages/team-management/src/components/TeamsView/tests/index.test.tsx
+++ b/packages/team-management/src/components/TeamsView/tests/index.test.tsx
@@ -167,7 +167,9 @@ describe('components/TeamsView', () => {
       await flushPromises();
     });
 
-    expect(mockNotificationError).toHaveBeenCalledWith('An error occurred');
+    expect(mockNotificationError).toHaveBeenCalledWith(
+      'There was a problem fetching Organizations'
+    );
     wrapper.unmount();
   });
 


### PR DESCRIPTION
Changes the error messages returned by failed request to messages with a bit more context of the source/cause of the error. 
closes #1193 