### PR TITLE
Enable password reset for practitioners

### DIFF
--- a/packages/fhir-keycloak-user-management/src/components/UserList/ListView/index.tsx
+++ b/packages/fhir-keycloak-user-management/src/components/UserList/ListView/index.tsx
@@ -82,7 +82,8 @@ export const UserList = (props: OrganizationListProps) => {
     extraData,
     queryClient,
     t,
-    onViewDetails
+    onViewDetails,
+    history
   );
 
   const searchFormProps = {

--- a/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
+++ b/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
@@ -15,7 +15,7 @@ import { Column } from '@opensrp/react-utils';
 import { sendErrorNotification } from '@opensrp/notifications';
 import { QueryClient } from 'react-query';
 import type { TFunction } from '@opensrp/i18n';
-import { history } from '@onaio/connected-reducer-registry';
+import { History } from 'history';
 
 /**
  * Get table columns for user list
@@ -26,6 +26,7 @@ import { history } from '@onaio/connected-reducer-registry';
  * @param queryClient - react query client
  * @param t - translator function
  * @param onViewDetails - callback when view details is clicked.
+ * @param history - history object for managing navigation
  */
 export const getTableColumns = (
   keycloakBaseUrl: string,
@@ -33,7 +34,8 @@ export const getTableColumns = (
   extraData: Dictionary,
   queryClient: QueryClient,
   t: TFunction,
-  onViewDetails: (recordId: string) => void
+  onViewDetails: (recordId: string) => void,
+  history: History
 ): Column<KeycloakUser>[] => {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { user_id } = extraData;

--- a/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
+++ b/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
@@ -3,8 +3,8 @@ import { Popconfirm, Divider, Dropdown, Button } from 'antd';
 import type { MenuProps } from 'antd';
 import { MoreOutlined } from '@ant-design/icons';
 import { deleteUser } from './utils';
-import { Link } from 'react-router-dom';
-import { KeycloakUser, URL_USER_EDIT, KEYCLOAK_URL_USERS } from '@opensrp/user-management';
+import { Link, useHistory } from 'react-router-dom';
+import { KeycloakUser, URL_USER_EDIT, KEYCLOAK_URL_USERS, URL_USER_CREDENTIALS } from '@opensrp/user-management';
 import { Dictionary } from '@onaio/utils';
 import { Column } from '@opensrp/react-utils';
 import { sendErrorNotification } from '@opensrp/notifications';
@@ -34,6 +34,7 @@ export const getTableColumns = (
   const headerItems: string[] = [t('First name'), t('Last name'), t('Username')];
   const dataElements: Column<KeycloakUser>[] = [];
   const fields: string[] = ['firstName', 'lastName', 'username'];
+  const history = useHistory();
 
   fields.forEach((field: string, index: number) => {
     dataElements.push({
@@ -84,6 +85,18 @@ export const getTableColumns = (
             ))}
         </Popconfirm>
       ),
+     },
+      {
+        key: '3',
+        label: (
+          <Button
+            type="link"
+            data-testid="credentials"
+            onClick={() => history.push(`${URL_USER_CREDENTIALS}/${record.id}`)}
+          >
+            {t('Credentials')}
+          </Button>
+        ),
     },
   ];
 

--- a/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
+++ b/packages/fhir-keycloak-user-management/src/components/UserList/ListView/tableColumns.tsx
@@ -3,13 +3,19 @@ import { Popconfirm, Divider, Dropdown, Button } from 'antd';
 import type { MenuProps } from 'antd';
 import { MoreOutlined } from '@ant-design/icons';
 import { deleteUser } from './utils';
-import { Link, useHistory } from 'react-router-dom';
-import { KeycloakUser, URL_USER_EDIT, KEYCLOAK_URL_USERS, URL_USER_CREDENTIALS } from '@opensrp/user-management';
+import { Link } from 'react-router-dom';
+import {
+  KeycloakUser,
+  URL_USER_EDIT,
+  KEYCLOAK_URL_USERS,
+  URL_USER_CREDENTIALS,
+} from '@opensrp/user-management';
 import { Dictionary } from '@onaio/utils';
 import { Column } from '@opensrp/react-utils';
 import { sendErrorNotification } from '@opensrp/notifications';
 import { QueryClient } from 'react-query';
 import type { TFunction } from '@opensrp/i18n';
+import { history } from '@onaio/connected-reducer-registry';
 
 /**
  * Get table columns for user list
@@ -34,7 +40,6 @@ export const getTableColumns = (
   const headerItems: string[] = [t('First name'), t('Last name'), t('Username')];
   const dataElements: Column<KeycloakUser>[] = [];
   const fields: string[] = ['firstName', 'lastName', 'username'];
-  const history = useHistory();
 
   fields.forEach((field: string, index: number) => {
     dataElements.push({
@@ -85,18 +90,18 @@ export const getTableColumns = (
             ))}
         </Popconfirm>
       ),
-     },
-      {
-        key: '3',
-        label: (
-          <Button
-            type="link"
-            data-testid="credentials"
-            onClick={() => history.push(`${URL_USER_CREDENTIALS}/${record.id}`)}
-          >
-            {t('Credentials')}
-          </Button>
-        ),
+    },
+    {
+      key: '3',
+      label: (
+        <Button
+          type="link"
+          data-testid="credentials"
+          onClick={() => history.push(`${URL_USER_CREDENTIALS}/${record.id}`)}
+        >
+          {t('Credentials')}
+        </Button>
+      ),
     },
   ];
 


### PR DESCRIPTION
closes #1246 
Add credentials option in dropdown options in user management that prompts the user for a new password and sets it as the new password.

![new-screenshot](https://github.com/opensrp/web/assets/67924109/6fd53ce8-4e7b-4dbe-af7e-979a3bf5d59a)
