### PR TITLE
Filter only active practitioners to be available for assigment

### DIFF
--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -56,7 +56,6 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     {
       select: (res) => getResourcesFromBundle(res) as IPractitionerRole[],
       onError: () => sendErrorNotification(t('There was a problem fetching practitioners')),
-      staleTime: 0,
     }
   );
 
@@ -71,7 +70,6 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
         return getResourcesFromBundle(res) as IPractitionerRole[];
       },
       enabled: !!orgId,
-      staleTime: 0,
     }
   );
 

--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -52,7 +52,7 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
 
   const practitioners = useQuery(
     [practitionerResourceType],
-    () => loadAllResources(fhirBaseUrl, practitionerResourceType),
+    () => loadAllResources(fhirBaseUrl, practitionerResourceType, { active: true }),
     {
       select: (res) => getResourcesFromBundle(res) as IPractitionerRole[],
       onError: () => sendErrorNotification(t('There was a problem fetching practitioners')),
@@ -62,7 +62,7 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
   // practitioners already assigned to this organization
   const allPractitionerRoles = useQuery(
     [practitionerResourceType, organizationResourceType, orgId],
-    () => loadAllResources(fhirBaseUrl, practitionerRoleResourceType),
+    () => loadAllResources(fhirBaseUrl, practitionerRoleResourceType, { active: true }),
     {
       onError: () =>
         sendErrorNotification(t('There was a problem fetching assigned practitioners')),

--- a/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/index.tsx
@@ -56,6 +56,7 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
     {
       select: (res) => getResourcesFromBundle(res) as IPractitionerRole[],
       onError: () => sendErrorNotification(t('There was a problem fetching practitioners')),
+      staleTime: 0,
     }
   );
 
@@ -70,13 +71,17 @@ export const AddEditOrganization = (props: AddEditOrganizationProps) => {
         return getResourcesFromBundle(res) as IPractitionerRole[];
       },
       enabled: !!orgId,
+      staleTime: 0,
     }
   );
 
   if (
-    (!organization.isIdle && organization.isLoading) ||
-    (!practitioners.isIdle && practitioners.isLoading) ||
-    (!allPractitionerRoles.isIdle && allPractitionerRoles.isLoading)
+    organization.isLoading ||
+    organization.isFetching ||
+    practitioners.isLoading ||
+    practitioners.isFetching ||
+    allPractitionerRoles.isLoading ||
+    allPractitionerRoles.isFetching
   ) {
     return <Spin size="large" className="custom-spinner"></Spin>;
   }

--- a/packages/fhir-team-management/src/components/AddEditOrganization/tests/index.test.tsx
+++ b/packages/fhir-team-management/src/components/AddEditOrganization/tests/index.test.tsx
@@ -101,20 +101,20 @@ test('renders correctly for edit locations', async () => {
 
   nock(props.fhirBaseURL)
     .get(`/${practitionerResourceType}/_search`)
-    .query({ _summary: 'count' })
+    .query({ _summary: 'count', active: true })
     .reply(200, { total: 1000 })
     .get(`/${practitionerResourceType}/_search`)
-    .query({ _count: 1000 })
+    .query({ _count: 1000, active: true })
     .reply(200, allPractitioners);
 
   nock(props.fhirBaseURL).get(`/${organizationResourceType}/${org105.id}`).reply(200, org105);
 
   nock(props.fhirBaseURL)
     .get(`/${practitionerRoleResourceType}/_search`)
-    .query({ _summary: 'count' })
+    .query({ _summary: 'count', active: true })
     .reply(200, { total: 1000 })
     .get(`/${practitionerRoleResourceType}/_search`)
-    .query({ _count: 1000 })
+    .query({ _count: 1000, active: true })
     .reply(200, allPractitioners);
 
   render(


### PR DESCRIPTION
close #1255

Add active filter when fetching for practitioners to assign to organizations, and when fetching practitionerRoles.
Caveat, to prevent a flash of content we also now enforce a loader till data is refetched.